### PR TITLE
Update documentation about mode, remove unused param

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ column names for the configured table and set them in memory.
 
 ## Configuration Options
 
-| name             | description                                                                                                                     | required             | default              |
-|------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------|----------------------|
-| table            | the name of the table in Postgres that the connector should read                                                                | yes                  | n/a                  |
-| url              | formatted connection string to the database.                                                                                    | yes                  | n/a                  |
-| columns          | comma separated string list of column names that should be built in to each Record's payload.                                   | no                   | `*` (all columns)    |
-| key              | column name that records should use for their `Key` fields. defaults to the column's primary key if nothing is specified        | no                   | primary key of table |
-| mode             | the connector's operation mode. Available modes: `cdc`, `snapshot`                                                              | no                   | `cdc`                |
-| publication_name | name of the publication to listen for WAL events                                                                                | req. for CDC mode    | `pglogrepl`          |
-| slot_name        | name of the slot opened for replication events                                                                                  | req. for CDC mode    | `pglogrepl_demo`     |
+| name             | description                                                                                                              | required          | default              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------- | -------------------- |
+| table            | the name of the table in Postgres that the connector should read                                                         | yes               | n/a                  |
+| url              | formatted connection string to the database.                                                                             | yes               | n/a                  |
+| columns          | comma separated string list of column names that should be built in to each Record's payload.                            | no                | `*` (all columns)    |
+| key              | column name that records should use for their `Key` fields. defaults to the column's primary key if nothing is specified | no                | primary key of table |
+| mode             | the connector's operation mode. Available modes: `cdc`, `snapshot`                                                       | no                | `cdc`                |
+| publication_name | name of the publication to listen for WAL events                                                                         | req. for CDC mode | `conduitpub`         |
+| slot_name        | name of the slot opened for replication events                                                                           | req. for CDC mode | `conduitslot`        |
 
 # Destination 
 The Postgres Destination takes a `record.Record` and parses it into a valid 

--- a/README.md
+++ b/README.md
@@ -41,19 +41,17 @@ Publication and slot name are user configurable, and must be correctly set.
 The plugin will do what it can to be smart about publication and slot 
 management, but it can't handle everything.
 
-If a `replication_url` is provided, it will be used for CDC features instead of 
-the url. If no `replication_url` is provided, but cdc is enabled, then it will 
-attempt to use that url value for CDC features and logical replication setup.
 Example configuration for CDC features:
-```
-"cdc":              "true",
-"publication_name": "meroxademo",
-"slot_name":        "meroxademo",
-"url":              url,
-"replication_url":  url,
-"key":              "key",
-"table":            "records",
-"columns":          "key,column1,column2,column3",
+```json
+{
+ "mode": "cdc",
+ "publication_name": "meroxademo",
+ "slot_name": "meroxademo",
+ "url": "url",
+ "key": "key",
+ "table": "records",
+ "columns": "key,column1,column2,column3"
+}
 ```
 
 ### CDC Event Buffer
@@ -84,7 +82,6 @@ column names for the configured table and set them in memory.
 | mode             | the connector's operation mode. Available modes: `cdc`, `snapshot`                                                              | no                   | `cdc`                |
 | publication_name | name of the publication to listen for WAL events                                                                                | req. for CDC mode    | `pglogrepl`          |
 | slot_name        | name of the slot opened for replication events                                                                                  | req. for CDC mode    | `pglogrepl_demo`     |
-| replication_url  | URL for the CDC connection to use. If no replication_url is provided, then the CDC connection attempts the use the `url` value. | optional in CDC mode | n/a                  |
 
 # Destination 
 The Postgres Destination takes a `record.Record` and parses it into a valid 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,12 @@ column names for the configured table and set them in memory.
 ## Configuration Options
 
 | name             | description                                                                                                                     | required             | default              |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------|----------------------|
 | table            | the name of the table in Postgres that the connector should read                                                                | yes                  | n/a                  |
 | url              | formatted connection string to the database.                                                                                    | yes                  | n/a                  |
 | columns          | comma separated string list of column names that should be built in to each Record's payload.                                   | no                   | `*` (all columns)    |
 | key              | column name that records should use for their `Key` fields. defaults to the column's primary key if nothing is specified        | no                   | primary key of table |
-| snapshot         | whether or not the plugin will take a snapshot of the entire table acquiring a read level lock before starting cdc mode         | n/a                  | enabled              |
-| cdc              | enables CDC features                                                                                                            | req. for CDC mode    | off                  |
+| mode             | the connector's operation mode. Available modes: `cdc`, `snapshot`                                                              | no                   | `cdc`                |
 | publication_name | name of the publication to listen for WAL events                                                                                | req. for CDC mode    | `pglogrepl`          |
 | slot_name        | name of the slot opened for replication events                                                                                  | req. for CDC mode    | `pglogrepl_demo`     |
 | replication_url  | URL for the CDC connection to use. If no replication_url is provided, then the CDC connection attempts the use the `url` value. | optional in CDC mode | n/a                  |


### PR DESCRIPTION
### Description

1. Updates documentation about operation mode (cdc, snapshot)
2. Removes unused `replication_url` parameter.


### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests. -- not needed
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
