### PR TITLE
Config options "cdc_mode" and "snapshot_mode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,16 @@ column names for the configured table and set them in memory.
 
 ## Configuration Options
 
-| name             | description                                                                                                                     | required             | default              |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
-| table            | the name of the table in Postgres that the connector should read                                                                | yes                  | n/a                  |
-| url              | formatted connection string to the database.                                                                                    | yes                  | n/a                  |
-| columns          | comma separated string list of column names that should be built in to each Record's payload.                                   | no                   | `*` (all columns)    |
-| key              | column name that records should use for their `Key` fields. defaults to the column's primary key if nothing is specified        | no                   | primary key of table |
-| snapshot         | whether or not the plugin will take a snapshot of the entire table acquiring a read level lock before starting cdc mode         | n/a                  | enabled              |
-| cdc              | enables CDC features                                                                                                            | req. for CDC mode    | off                  |
-| publication_name | name of the publication to listen for WAL events                                                                                | req. for CDC mode    | `pglogrepl`          |
-| slot_name        | name of the slot opened for replication events                                                                                  | req. for CDC mode    | `pglogrepl_demo`     |
-| replication_url  | URL for the CDC connection to use. If no replication_url is provided, then the CDC connection attempts the use the `url` value. | optional in CDC mode | n/a                  |
+| name             | description                                                                                                                                                    | required             | default                |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ---------------------- |
+| table            | the name of the table in Postgres that the connector should read                                                                                               | yes                  | n/a                    |
+| url              | formatted connection string to the database.                                                                                                                   | yes                  | n/a                    |
+| columns          | comma separated string list of column names that should be built in to each Record's payload.                                                                  | no                   | (all columns)          |
+| key              | column name that records should use for their `Key` fields. defaults to the column's primary key if nothing is specified                                       | no                   | (primary key of table) |
+| snapshot_mode    | whether or not the plugin will take a snapshot of the entire table acquiring a read level lock before starting cdc mode (allowed values: `initial` or `never`) | no                   | `initial`              |
+| cdc_mode         | determines the CDC mode (allowed values: `auto`, `logrepl` or `long_polling`)                                                                                  | no                   | `auto`                 |
+| publication_name | name of the publication to listen for WAL events                                                                                                               | no                   | `conduitpub`           |
+| slot_name        | name of the slot opened for replication events                                                                                                                 | no                   | `conduitslot`          |
 
 # Destination 
 The Postgres Destination takes a `record.Record` and parses it into a valid 

--- a/source/config_test.go
+++ b/source/config_test.go
@@ -42,36 +42,60 @@ func TestParseConfig(t *testing.T) {
 			cfg.Columns = []string{"col1", "col2", "col3"}
 		},
 	}, {
-		name: "snapshot mode",
+		name: "snapshot mode = initial",
 		setupGiven: func(cfg map[string]string) {
-			cfg[ConfigKeyMode] = "snapshot"
+			cfg[ConfigKeySnapshotMode] = "initial"
 		},
 		setupWant: func(cfg *Config) {
-			cfg.Mode = ModeSnapshot
+			cfg.SnapshotMode = SnapshotModeInitial
 		},
 	}, {
-		name: "cdc mode",
+		name: "snapshot mode = never",
 		setupGiven: func(cfg map[string]string) {
-			cfg[ConfigKeyMode] = "cdc"
+			cfg[ConfigKeySnapshotMode] = "never"
 		},
 		setupWant: func(cfg *Config) {
-			cfg.Mode = ModeCDC
+			cfg.SnapshotMode = SnapshotModeNever
+		},
+	}, {
+		name: "cdc mode = auto",
+		setupGiven: func(cfg map[string]string) {
+			cfg[ConfigKeyCDCMode] = "auto"
+		},
+		setupWant: func(cfg *Config) {
+			cfg.CDCMode = CDCModeAuto
+		},
+	}, {
+		name: "cdc mode = logrepl",
+		setupGiven: func(cfg map[string]string) {
+			cfg[ConfigKeyCDCMode] = "logrepl"
+		},
+		setupWant: func(cfg *Config) {
+			cfg.CDCMode = CDCModeLogrepl
+		},
+	}, {
+		name: "cdc mode = long_polling",
+		setupGiven: func(cfg map[string]string) {
+			cfg[ConfigKeyCDCMode] = "long_polling"
+		},
+		setupWant: func(cfg *Config) {
+			cfg.CDCMode = CDCModeLongPolling
 		},
 	}, {
 		name: "publication name",
 		setupGiven: func(cfg map[string]string) {
-			cfg[ConfigKeyPublicationName] = "mypublicationname"
+			cfg[ConfigKeyLogreplPublicationName] = "mypublicationname"
 		},
 		setupWant: func(cfg *Config) {
-			cfg.PublicationName = "mypublicationname"
+			cfg.LogreplPublicationName = "mypublicationname"
 		},
 	}, {
 		name: "slot name",
 		setupGiven: func(cfg map[string]string) {
-			cfg[ConfigKeySlotName] = "myslotname"
+			cfg[ConfigKeyLogreplSlotName] = "myslotname"
 		},
 		setupWant: func(cfg *Config) {
-			cfg.SlotName = "myslotname"
+			cfg.LogreplSlotName = "myslotname"
 		},
 	}, {
 		name: "empty url",
@@ -86,11 +110,17 @@ func TestParseConfig(t *testing.T) {
 		},
 		wantErr: errors.New(`"table" config value must be set`),
 	}, {
-		name: "invalid mode",
+		name: "snapshot mode = invalid",
 		setupGiven: func(cfg map[string]string) {
-			cfg[ConfigKeyMode] = "invalid"
+			cfg[ConfigKeySnapshotMode] = "invalid"
 		},
-		wantErr: errors.New(`"mode" contains unsupported value "invalid", expected one of [full snapshot cdc]`),
+		wantErr: errors.New(`"snapshot_mode" contains unsupported value "invalid", expected one of [initial never]`),
+	}, {
+		name: "cdc mode = invalid",
+		setupGiven: func(cfg map[string]string) {
+			cfg[ConfigKeyCDCMode] = "invalid"
+		},
+		wantErr: errors.New(`"cdc_mode" contains unsupported value "invalid", expected one of [auto logrepl long_polling]`),
 	}}
 
 	for _, tc := range testCases {
@@ -108,11 +138,12 @@ func TestParseConfig(t *testing.T) {
 
 				// want is parsed corresponding to the basic valid config
 				want := Config{
-					URL:             "postgres://user:pass@localhost:5432/testdb?sslmode=disable",
-					Table:           "my_table",
-					Mode:            ModeFull,
-					PublicationName: DefaultPublicationName,
-					SlotName:        DefaultSlotName,
+					URL:                    "postgres://user:pass@localhost:5432/testdb?sslmode=disable",
+					Table:                  "my_table",
+					SnapshotMode:           SnapshotModeInitial,
+					CDCMode:                CDCModeAuto,
+					LogreplPublicationName: DefaultPublicationName,
+					LogreplSlotName:        DefaultSlotName,
 				}
 				tc.setupWant(&want)
 				is.Equal(got, want)


### PR DESCRIPTION
### Description

This change removes the `mode` option and instead introduces two options:
- `snapshot_mode` - can be used to turn snapshot on/off, right now two options are supported: `initial` (default) enables the snapshot at the start, `never` turns the snapshot off.
- `cdc_mode` - can be used to pick the mode of detecting CDC changes, right now three options are supported: `auto` (default) detects if logical replication is supported and falls back to long polling if it's not, `logrepl` forces logical replication, `long_polling` forces long polling.

This PR also fixes the long polling snapshot iterator by removing `HasNext`, since the source doesn't call that method.

Based on #11.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
