### PR TITLE
adds delete handler to destination

### DIFF
--- a/destination/destination.go
+++ b/destination/destination.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	sdk "github.com/conduitio/conduit-connector-sdk"
@@ -175,7 +174,6 @@ func (d *Destination) upsert(ctx context.Context, r sdk.Record) error {
 }
 
 func (d *Destination) remove(ctx context.Context, r sdk.Record) error {
-	log.Printf("REMOVE HIT - %v", r)
 	key, err := getKey(r)
 	if err != nil {
 		return err
@@ -192,8 +190,6 @@ func (d *Destination) remove(ctx context.Context, r sdk.Record) error {
 	if err != nil {
 		return fmt.Errorf("error formatting insert query: %w", err)
 	}
-	log.Printf("QUERY: %v", query)
-	log.Printf("ARGS: %v", args)
 	_, err = d.conn.Exec(ctx, query, args...)
 	return err
 }
@@ -334,7 +330,8 @@ func (d *Destination) getTableName(metadata map[string]string) (string, error) {
 	return tableName, nil
 }
 
-// getKeyColumnName will return the name of the first item in the key.
+// getKeyColumnName will return the name of the first item in the key or the
+// connector-configured default name of the key column name.
 func getKeyColumnName(key sdk.StructuredData, defaultKeyName string) string {
 	if len(key) > 1 {
 		// Go maps aren't order preserving, so anything over len 1 will have

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -188,7 +188,7 @@ func (d *Destination) remove(ctx context.Context, r sdk.Record) error {
 		Where(sq.Eq{keyColumnName: key[keyColumnName]}).
 		ToSql()
 	if err != nil {
-		return fmt.Errorf("error formatting insert query: %w", err)
+		return fmt.Errorf("error formatting delete query: %w", err)
 	}
 	_, err = d.conn.Exec(ctx, query, args...)
 	return err

--- a/destination/destination_test.go
+++ b/destination/destination_test.go
@@ -142,6 +142,27 @@ func TestAdapter_Write(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "delete by key",
+			fields: fields{
+				conn:   getTestPostgres(t),
+				config: config{},
+			},
+			args: args{
+				ctx: context.Background(),
+				record: sdk.Record{
+					Position: sdk.Position("617237"),
+					Metadata: map[string]string{
+						"table":  "keyed",
+						"action": "delete",
+					},
+					Key: sdk.StructuredData{
+						"key": "3",
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Description

Adds delete handling to the destination connector.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
