### PR TITLE
adds snapshot capabilities to logical replication iterator

### DIFF
--- a/source/logrepl/iterator.go
+++ b/source/logrepl/iterator.go
@@ -27,6 +27,7 @@ import (
 
 // Config holds configuration values for CDCIterator.
 type Config struct {
+	SnapshotMode    string
 	Position        sdk.Position
 	SlotName        string
 	PublicationName string
@@ -35,25 +36,35 @@ type Config struct {
 	Columns         []string
 }
 
-// CDCIterator asynchronously listens for events from the logical replication
+// Iterator asynchronously listens for events from the logical replication
 // slot and returns them to the caller through Next.
-type CDCIterator struct {
+type Iterator struct {
 	config  Config
 	records chan sdk.Record
 
-	sub *internal.Subscription
+	snap *SnapshotIterator
+	sub  *internal.Subscription
 }
 
-// NewCDCIterator sets up the subscription to a logical replication slot and
+// NewIterator sets up the subscription to a logical replication slot and
 // starts a goroutine that listens to events. The goroutine will keep running
 // until either the context is canceled or Teardown is called.
-func NewCDCIterator(ctx context.Context, conn *pgx.Conn, config Config) (*CDCIterator, error) {
-	i := &CDCIterator{
+// * If SnapshotMode is set to `initial`, it waits for a snapshot of the
+// configured table to finish before starting its replication subscription.
+// * If SnapshotMode is set to `never`, it will skip the snapshot and
+// immediately start listening for replication events.
+func NewIterator(ctx context.Context, conn *pgx.Conn, config Config) (*Iterator, error) {
+	i := &Iterator{
 		config:  config,
 		records: make(chan sdk.Record),
 	}
 
-	err := i.attachSubscription(ctx, conn)
+	err := i.attachSnapshot(ctx, conn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup snapshot: %w", err)
+	}
+
+	err = i.attachSubscription(ctx, conn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup subscription: %w", err)
 	}
@@ -65,7 +76,13 @@ func NewCDCIterator(ctx context.Context, conn *pgx.Conn, config Config) (*CDCIte
 
 // listen should be called in a goroutine. It starts the subscription and keeps
 // it running until the subscription is stopped or the context is canceled.
-func (i *CDCIterator) listen(ctx context.Context) {
+// if snapshot mode is set to `initial`, this waits for the snapshot to complete
+// before starting the subscription.
+func (i *Iterator) listen(ctx context.Context) {
+	if i.config.SnapshotMode == "initial" {
+		<-i.snap.Done()
+	}
+
 	sdk.Logger(ctx).Info().
 		Str("slot", i.config.SlotName).
 		Str("publication", i.config.PublicationName).
@@ -80,10 +97,27 @@ func (i *CDCIterator) listen(ctx context.Context) {
 	}
 }
 
-// Next returns the next record retrieved from the subscription. This call will
-// block until either a record is returned from the subscription, the
-// subscription stops because of an error or the context gets canceled.
-func (i *CDCIterator) Next(ctx context.Context) (sdk.Record, error) {
+// Next checks if its snapshot is finished and returns a record from the
+// snapshot if it's not. If it is finished, it returns the next record retrieved
+// from the subscription. Once it's finished with the snapshot, it blocks until
+// either a record is returned from subscription, the subscription stops because
+// of an error, or the context is canceled.
+func (i *Iterator) Next(ctx context.Context) (sdk.Record, error) {
+	if !i.snap.Finished() {
+		r, err := i.snap.Next(ctx)
+		if err != nil {
+			if errors.Is(err, ErrSnapshotComplete) {
+				err := i.snap.Teardown(ctx)
+				if err != nil {
+					return sdk.Record{}, fmt.Errorf("failed to teardown snapshot connector: %w", err)
+				}
+				return i.Next(ctx)
+			}
+			return sdk.Record{}, fmt.Errorf("snapshot iterator failed: %w", err)
+		}
+		return r, nil
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -107,7 +141,7 @@ func (i *CDCIterator) Next(ctx context.Context) (sdk.Record, error) {
 }
 
 // Ack forwards the acknowledgment to the subscription.
-func (i *CDCIterator) Ack(ctx context.Context, pos sdk.Position) error {
+func (i *Iterator) Ack(ctx context.Context, pos sdk.Position) error {
 	lsn, err := PositionToLSN(pos)
 	if err != nil {
 		return fmt.Errorf("failed to parse position: %w", err)
@@ -119,8 +153,19 @@ func (i *CDCIterator) Ack(ctx context.Context, pos sdk.Position) error {
 // Teardown stops the CDC subscription and blocks until the subscription is done
 // or the context gets canceled. If the subscription stopped with an unexpected
 // error, the error is returned.
-func (i *CDCIterator) Teardown(ctx context.Context) error {
+func (i *Iterator) Teardown(ctx context.Context) error {
 	i.sub.Stop()
+
+	if i.snap != nil {
+		sdk.Logger(ctx).Info().Msg("tearing down snapshotter")
+		snapErr := i.snap.Teardown(ctx)
+		if snapErr != nil {
+			sdk.Logger(ctx).
+				Info().
+				Msgf("failed to teardown snapshot iterator: %v", snapErr)
+		}
+	}
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -138,7 +183,7 @@ func (i *CDCIterator) Teardown(ctx context.Context) error {
 
 // attachSubscription determines the starting LSN and key column of the source
 // table and prepares a subscription.
-func (i *CDCIterator) attachSubscription(ctx context.Context, conn *pgx.Conn) error {
+func (i *Iterator) attachSubscription(ctx context.Context, conn *pgx.Conn) error {
 	var lsn pglogrepl.LSN
 	if i.config.Position != nil && string(i.config.Position) != "" {
 		var err error
@@ -171,9 +216,31 @@ func (i *CDCIterator) attachSubscription(ctx context.Context, conn *pgx.Conn) er
 	return nil
 }
 
+// attachSnapshot checks if a snapshot should be taken and attaches
+// a snapshot iterator if it should. If Position is not set in the config, it
+// sets the current subscription's position to the snapshot's anchored LSN.
+func (i *Iterator) attachSnapshot(ctx context.Context, conn *pgx.Conn) error {
+	if i.config.SnapshotMode == "never" {
+		return nil
+	}
+	snap, err := NewSnapshotIterator(ctx, conn, Config{
+		TableName:     i.config.TableName,
+		Columns:       i.config.Columns,
+		KeyColumnName: i.config.KeyColumnName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to setup snapshot iterator: %w", err)
+	}
+	if i.config.Position == nil {
+		i.config.Position = sdk.Position(snap.LSN())
+	}
+	i.snap = snap
+	return nil
+}
+
 // getKeyColumn queries the db for the name of the primary key column for a
 // table if one exists and returns it.
-func (i *CDCIterator) getKeyColumn(ctx context.Context, conn *pgx.Conn) (string, error) {
+func (i *Iterator) getKeyColumn(ctx context.Context, conn *pgx.Conn) (string, error) {
 	if i.config.KeyColumnName != "" {
 		return i.config.KeyColumnName, nil
 	}

--- a/source/logrepl/iterator.go
+++ b/source/logrepl/iterator.go
@@ -80,10 +80,6 @@ func NewIterator(ctx context.Context, conn *pgx.Conn, config Config) (*Iterator,
 // if snapshot mode is set to `initial`, this waits for the snapshot to complete
 // before starting the subscription.
 func (i *Iterator) listen(ctx context.Context) {
-	if i.config.SnapshotMode == "initial" {
-		<-i.snap.Done()
-	}
-
 	sdk.Logger(ctx).Info().
 		Str("slot", i.config.SlotName).
 		Str("publication", i.config.PublicationName).

--- a/source/logrepl/iterator_test.go
+++ b/source/logrepl/iterator_test.go
@@ -135,10 +135,10 @@ func TestSnapshotTransition(t *testing.T) {
 	pool := test.ConnectPool(ctx, t, test.RepmgrConnString)
 	table := test.SetupTestTable(ctx, t, pool)
 	i := testIterator(ctx, t, pool, table)
+	i.config.SnapshotMode = "initial"
 	t.Cleanup(func() {
 		is.NoErr(i.Teardown(ctx))
 	})
-
 	go func() {
 		count := 0
 		for {

--- a/source/logrepl/position.go
+++ b/source/logrepl/position.go
@@ -15,6 +15,9 @@
 package logrepl
 
 import (
+	"fmt"
+	"strconv"
+
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/jackc/pglogrepl"
 )
@@ -27,4 +30,12 @@ func LSNToPosition(lsn pglogrepl.LSN) sdk.Position {
 // PositionToLSN converts a Conduit position to a Postgres LSN.
 func PositionToLSN(pos sdk.Position) (pglogrepl.LSN, error) {
 	return pglogrepl.ParseLSN(string(pos))
+}
+
+func SnapshotPosition(table string, inpos int64) sdk.Position {
+	position := fmt.Sprintf("%s:%s:%s",
+		snapshotPrefix,
+		table,
+		strconv.FormatInt(inpos, 10))
+	return sdk.Position(position)
 }

--- a/source/source.go
+++ b/source/source.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	_ Iterator = (*logrepl.CDCIterator)(nil)
+	_ Iterator = (*logrepl.Iterator)(nil)
 	_ Iterator = (*longpoll.SnapshotIterator)(nil)
 )
 
@@ -63,13 +63,8 @@ func (s *Source) Open(ctx context.Context, pos sdk.Position) error {
 		//  switches to long polling if it's not. For now use logical replication
 		fallthrough
 	case CDCModeLogrepl:
-		if s.config.SnapshotMode == SnapshotModeInitial {
-			// TODO create snapshot iterator for logical replication and pass
-			//  the snapshot mode in the config
-			sdk.Logger(ctx).Warn().Msg("snapshot not supported in logical replication mode")
-		}
-
-		i, err := logrepl.NewCDCIterator(ctx, s.conn, logrepl.Config{
+		i, err := logrepl.NewIterator(ctx, s.conn, logrepl.Config{
+			SnapshotMode:    string(s.config.SnapshotMode),
 			Position:        pos,
 			SlotName:        s.config.LogreplSlotName,
 			PublicationName: s.config.LogreplPublicationName,


### PR DESCRIPTION
### Description

This PR refactors the `CDCIterator` into a combined `Iterator` that takes
a snapshot if configured to do so and then switches into logical replication
mode at its anchored LSN position.

Fixes #15

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
