### PR TITLE
Fix TestRelationSetAllTypes

### DIFF
--- a/source/logrepl/internal/relationset_test.go
+++ b/source/logrepl/internal/relationset_test.go
@@ -61,9 +61,7 @@ func TestRelationSetAllTypes(t *testing.T) {
 	for {
 		// first message needs to be a begin message
 		msg := <-messages
-		if _, ok := msg.(*pglogrepl.BeginMessage); !ok {
-			t.Fatalf("expected begin message, got %s", msg.Type())
-		}
+		_ = msg.(*pglogrepl.BeginMessage)
 
 		// second message can be either commit (we can catch empty transactions)
 		// or relation (that's what we are actually interested in)
@@ -75,13 +73,7 @@ func TestRelationSetAllTypes(t *testing.T) {
 		// not an empty transaction, these have to be the messages we are looking for
 		rel = msg.(*pglogrepl.RelationMessage)        // second message is a relation
 		ins = (<-messages).(*pglogrepl.InsertMessage) // third one is the insert
-
-		// last one needs to be commit
-		msg = <-messages
-		if _, ok := msg.(*pglogrepl.CommitMessage); !ok {
-			t.Fatalf("expected commit message, got %s", msg.Type())
-		}
-
+		_ = (<-messages).(*pglogrepl.CommitMessage)   // fourth one is the commit
 		break
 	}
 


### PR DESCRIPTION
### Description

This changes `TestRelationSetAllTypes` so it is allowed to catch any number of empty transactions before getting to the one it actually expects.

Fixes #37

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
