### PR TITLE
adds copy data writer for snapshot capabilities

### DIFF
--- a/source/logrepl/copyto.go
+++ b/source/logrepl/copyto.go
@@ -1,0 +1,180 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logrepl
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/conduitio/conduit-connector-postgres/pgutil"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgproto3/v2"
+	"github.com/jackc/pgtype"
+	"github.com/jackc/pgx/v4"
+)
+
+type CopyDataWriter struct {
+	config            Config
+	conn              *pgx.Conn
+	fieldDescriptions []pgproto3.FieldDescription
+	decoders          []decoderValue
+	connInfo          *pgtype.ConnInfo
+	messages          chan sdk.Record
+	done              chan struct{}
+}
+
+// NewCopyDataWriter builds a new CopyDataWriter from a postgres connection.
+func NewCopyDataWriter(ctx context.Context, conn *pgx.Conn, config Config) (*CopyDataWriter, error) {
+	fds, err := getFieldDescriptions(ctx, conn.PgConn(), []string{config.TableName})
+	if err != nil {
+		return nil, err
+	}
+
+	decoders := make([]decoderValue, len(fds))
+	for i, fd := range fds {
+		decoders[i] = oidToDecoderValue(pgtype.OID(fd.DataTypeOID))
+	}
+
+	c := &CopyDataWriter{
+		conn:              conn,
+		config:            config,
+		fieldDescriptions: fds,
+		decoders:          decoders,
+		connInfo:          conn.ConnInfo(),
+		messages:          make(chan sdk.Record, 1),
+		done:              make(chan struct{}, 1),
+	}
+
+	return c, nil
+}
+
+// Copy is meant to be called concurrently after a writer is created.
+func (c *CopyDataWriter) Copy(ctx context.Context) {
+	copyquery := fmt.Sprintf("COPY %s TO STDOUT", c.config.TableName)
+	_, err := c.conn.PgConn().CopyTo(ctx, c, copyquery)
+	if err != nil {
+		fmt.Printf("failed to copy data from table: %v", err)
+	}
+	close(c.done)
+}
+
+func (c *CopyDataWriter) Write(line []byte) (n int, err error) {
+	tokens := bytes.Split(line, []byte{'\t'})
+	rec := sdk.Record{}
+	payload := sdk.StructuredData{}
+
+	for i, decoder := range c.decoders {
+		token := tokens[i]
+		if bytes.Equal(token, []byte(`\N`)) {
+			token = nil
+		}
+
+		err = decoder.DecodeText(c.connInfo, token)
+		if err != nil {
+			return 0, fmt.Errorf("failed to decode text: %v", err)
+		}
+
+		key := c.fieldDescriptions[i].Name
+		payload[string(key)] = decoder.Get()
+	}
+
+	rec.CreatedAt = time.Now()
+	rec.Payload = payload
+	rec.Key = sdk.StructuredData{}         // TODO
+	rec.Metadata = make(map[string]string) // TODO
+
+	c.messages <- rec
+
+	return len(line), nil
+}
+
+// Next returns the next message in the queue. It's a blocking operation to
+// match the Iterator pattern we've previously established.
+func (c *CopyDataWriter) Next(ctx context.Context) (sdk.Record, error) {
+	for {
+		select {
+		case msg := <-c.messages:
+			return msg, nil
+		case <-ctx.Done():
+			return sdk.Record{}, ctx.Err()
+		}
+	}
+}
+
+// Teardown closes the messages channel and returns.
+func (c *CopyDataWriter) Teardown(ctx context.Context) error {
+	close(c.messages)
+	return nil
+}
+
+func (c *CopyDataWriter) Ack(ctx context.Context, pos sdk.Position) error {
+	return nil // noop in copy writer terms
+}
+
+func (c *CopyDataWriter) Done() <-chan struct{} {
+	return c.done
+}
+
+func getFieldDescriptions(ctx context.Context, conn *pgconn.PgConn, table pgx.Identifier) ([]pgproto3.FieldDescription, error) {
+	mrr := conn.Exec(ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 0", table.Sanitize()))
+	hasNext := mrr.NextResult()
+	if !hasNext {
+		err := mrr.Close()
+		if err == nil {
+			// shouldn't happen, just to be safe
+			err = errors.New("MultiResultReader did not contain any results")
+		}
+		return nil, err
+	}
+
+	rr := mrr.ResultReader()
+	fds := rr.FieldDescriptions()
+
+	// NB: copy slice since it is reused for other queries after rr is closed
+	fdsCopy := make([]pgproto3.FieldDescription, len(fds))
+	copy(fdsCopy, fds)
+
+	_, err := rr.Close()
+	if err != nil {
+		_ = mrr.Close()
+		return nil, err
+	}
+
+	err = mrr.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return fdsCopy, nil
+}
+
+type decoderValue interface {
+	pgtype.Value
+	pgtype.TextDecoder
+}
+
+func oidToDecoderValue(id pgtype.OID) decoderValue {
+	t, ok := pgutil.OIDToPgType(id).(decoderValue)
+	if !ok {
+		// not all pg types implement pgtype.Value and pgtype.TextDecoder
+		return &pgtype.Unknown{}
+	}
+	return t
+}

--- a/source/logrepl/copyto_test.go
+++ b/source/logrepl/copyto_test.go
@@ -54,6 +54,9 @@ func TestCopyTo(t *testing.T) {
 		is.True(rec.CreatedAt.After(now))
 		count++
 	}
+
+	<-w.done
+	is.NoErr(w.Teardown(ctx))
 }
 
 func TestCopyWriter_Copy(t *testing.T) {
@@ -90,6 +93,9 @@ func TestCopyWriter_Copy(t *testing.T) {
 		is.True(rec.CreatedAt.After(now))
 		count++
 	}
+
+	<-w.done
+	is.NoErr(w.Teardown(ctx))
 }
 
 func TestCopyDataWriter_Next(t *testing.T) {
@@ -161,6 +167,9 @@ func TestCopyDataWriter_Next(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("wanted: %v - got: %v", tt.want, got)
 			}
+
+			<-w.done
+			is.NoErr(w.Teardown(ctx))
 		})
 	}
 }

--- a/source/logrepl/copyto_test.go
+++ b/source/logrepl/copyto_test.go
@@ -1,0 +1,180 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logrepl
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-connector-postgres/test"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/matryer/is"
+)
+
+func TestCopyTo(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	conn := test.ConnectSimple(ctx, t, "postgres://repmgr:repmgrmeroxa@localhost:5432/meroxadb?sslmode=disable&replication=database")
+
+	_, err := conn.Exec(ctx, `create temporary table foo( a int2, b int4, c int8, d varchar, e text, f date, g json)`)
+	is.NoErr(err)
+
+	_, err = conn.Exec(context.Background(), `insert into foo values (0, 1, 2, 'abc	', 'efg', '2000-01-01', '{"abc":"def","foo":"bar"}')`)
+	is.NoErr(err)
+
+	_, err = conn.Exec(context.Background(), `insert into foo values (3, null, null, null, null, null, '{"foo":"bar"}')`)
+	is.NoErr(err)
+
+	// --------------
+	// TODO make sure to filter by table_schema
+	// rows, err := conn.Query(ctx, "SELECT column_name, udt_name FROM information_schema.columns WHERE table_name = 'foo' ORDER BY ordinal_position")
+	// is.NoErr(err)
+	// --------------
+
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:       "REPEATABLE",
+		AccessMode:     "READ",
+		DeferrableMode: "",
+	})
+	is.NoErr(err)
+	t.Cleanup(func() { is.NoErr(tx.Commit(ctx)) })
+
+	w, err := NewCopyDataWriter(ctx, conn, Config{TableName: "foo"})
+	is.NoErr(err)
+	t.Cleanup(func() { w.Teardown(ctx) })
+
+	go w.Copy(ctx)
+
+	now := time.Now()
+	count := 0
+	for count < 2 {
+		rec, err := w.Next(ctx)
+		is.NoErr(err)
+		is.True(rec.CreatedAt.After(now))
+		count++
+	}
+}
+
+func TestCopyWriter_Copy(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	conn := test.ConnectSimple(ctx, t, "postgres://repmgr:repmgrmeroxa@localhost:5432/meroxadb?sslmode=disable&replication=database")
+
+	_, err := conn.Exec(ctx, `create temporary table foo( a int2, b int4, c int8, d varchar, e text, f date, g json)`)
+	is.NoErr(err)
+
+	_, err = conn.Exec(context.Background(), `insert into foo values (0, 1, 2, 'abc	', 'efg', '2000-01-01', '{"abc":"def","foo":"bar"}')`)
+	is.NoErr(err)
+
+	_, err = conn.Exec(context.Background(), `insert into foo values (3, null, null, null, null, null, '{"foo":"bar"}')`)
+	is.NoErr(err)
+
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   "REPEATABLE",
+		AccessMode: "READ",
+	})
+	is.NoErr(err)
+	defer tx.Commit(ctx)
+
+	w, err := NewCopyDataWriter(ctx, tx.Conn(), Config{TableName: "foo"})
+	is.NoErr(err)
+
+	go w.Copy(ctx)
+
+	now := time.Now()
+	count := 0
+	for count < 2 {
+		rec, err := w.Next(ctx)
+		is.NoErr(err)
+		is.True(rec.CreatedAt.After(now))
+		count++
+	}
+}
+
+func TestCopyDataWriter_Next(t *testing.T) {
+	is := is.New(t)
+	type args struct {
+		config Config
+	}
+	tests := []struct {
+		name       string
+		args       args
+		setupQuery func(conn *pgx.Conn)
+		wantErr    bool
+		want       sdk.Record
+	}{
+		{
+			name: "should parse a copy line into a record",
+			args: args{
+				config: Config{
+					TableName: "foo",
+				},
+			},
+			setupQuery: func(conn *pgx.Conn) {
+				_, err := conn.Exec(context.Background(), `create temporary table foo(a int2, b int4, c int8, d varchar, e text, f date, g json)`)
+				is.NoErr(err)
+				_, err = conn.Exec(context.Background(), `insert into foo 
+				values (0, 1, 2, 'abc	', 'efg', '2000-01-01', '{"abc":"def","foo":"bar"}')`)
+				is.NoErr(err)
+			},
+			wantErr: false,
+			want: sdk.Record{
+				Position: nil,                  // TODO
+				Metadata: map[string]string{},  // TODO
+				Key:      sdk.StructuredData{}, // TODO
+				Payload: sdk.StructuredData{
+					"a": int16(0),
+					"b": int32(1),
+					"c": int64(2),
+					"d": string(`abc\t`),
+					"e": string("efg"),
+					"f": time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+					"g": map[string]any{
+						"abc": string("def"),
+						"foo": string("bar"),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			conn := test.ConnectSimple(ctx, t, test.RepmgrConnString)
+			now := time.Now()
+			tt.setupQuery(conn)
+
+			w, err := NewCopyDataWriter(ctx, conn, tt.args.config)
+			is.NoErr(err)
+			go w.Copy(ctx)
+
+			got, err := w.Next(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CopyDataWriter.Write() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			is.True(got.CreatedAt.After(now))
+			got.CreatedAt = time.Time{} // TODO
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("wanted: %v - got: %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/source/logrepl/copyto_test.go
+++ b/source/logrepl/copyto_test.go
@@ -57,7 +57,7 @@ func TestCopyTo(t *testing.T) {
 
 	w, err := NewCopyDataWriter(ctx, conn, Config{TableName: "foo"})
 	is.NoErr(err)
-	t.Cleanup(func() { w.Teardown(ctx) })
+	t.Cleanup(func() { is.NoErr(w.Teardown(ctx)) })
 
 	go w.Copy(ctx)
 
@@ -90,7 +90,7 @@ func TestCopyWriter_Copy(t *testing.T) {
 		AccessMode: "READ",
 	})
 	is.NoErr(err)
-	defer tx.Commit(ctx)
+	defer is.NoErr(tx.Commit(ctx))
 
 	w, err := NewCopyDataWriter(ctx, tx.Conn(), Config{TableName: "foo"})
 	is.NoErr(err)

--- a/source/logrepl/copyto_test.go
+++ b/source/logrepl/copyto_test.go
@@ -30,7 +30,7 @@ import (
 func TestCopyTo(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
-	conn := test.ConnectSimple(ctx, t, "postgres://repmgr:repmgrmeroxa@localhost:5432/meroxadb?sslmode=disable&replication=database")
+	conn := test.ConnectSimple(ctx, t, test.RepmgrConnString)
 
 	_, err := conn.Exec(ctx, `create temporary table foo( a int2, b int4, c int8, d varchar, e text, f date, g json)`)
 	is.NoErr(err)
@@ -41,25 +41,10 @@ func TestCopyTo(t *testing.T) {
 	_, err = conn.Exec(context.Background(), `insert into foo values (3, null, null, null, null, null, '{"foo":"bar"}')`)
 	is.NoErr(err)
 
-	// --------------
-	// TODO make sure to filter by table_schema
-	// rows, err := conn.Query(ctx, "SELECT column_name, udt_name FROM information_schema.columns WHERE table_name = 'foo' ORDER BY ordinal_position")
-	// is.NoErr(err)
-	// --------------
-
-	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
-		IsoLevel:       "REPEATABLE",
-		AccessMode:     "READ",
-		DeferrableMode: "",
-	})
-	is.NoErr(err)
-	t.Cleanup(func() { is.NoErr(tx.Commit(ctx)) })
-
 	w, err := NewCopyDataWriter(ctx, conn, Config{TableName: "foo"})
 	is.NoErr(err)
-	t.Cleanup(func() { is.NoErr(w.Teardown(ctx)) })
 
-	go w.Copy(ctx)
+	go w.Copy(ctx, conn)
 
 	now := time.Now()
 	count := 0
@@ -74,7 +59,7 @@ func TestCopyTo(t *testing.T) {
 func TestCopyWriter_Copy(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
-	conn := test.ConnectSimple(ctx, t, "postgres://repmgr:repmgrmeroxa@localhost:5432/meroxadb?sslmode=disable&replication=database")
+	conn := test.ConnectSimple(ctx, t, test.RepmgrConnString)
 
 	_, err := conn.Exec(ctx, `create temporary table foo( a int2, b int4, c int8, d varchar, e text, f date, g json)`)
 	is.NoErr(err)
@@ -95,7 +80,7 @@ func TestCopyWriter_Copy(t *testing.T) {
 	w, err := NewCopyDataWriter(ctx, tx.Conn(), Config{TableName: "foo"})
 	is.NoErr(err)
 
-	go w.Copy(ctx)
+	go w.Copy(ctx, conn)
 
 	now := time.Now()
 	count := 0
@@ -162,7 +147,8 @@ func TestCopyDataWriter_Next(t *testing.T) {
 
 			w, err := NewCopyDataWriter(ctx, conn, tt.args.config)
 			is.NoErr(err)
-			go w.Copy(ctx)
+
+			go w.Copy(ctx, conn)
 
 			got, err := w.Next(ctx)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
### Description

This PR adds the `CopyDataWriter` iterator for capturing Postgres database
snapshots. 

Previously we attempted to use a replication slot combined with Postgres'
internal snapshot capabilities, however we couldn't use `SET SNAPSHOT` keywords
because replication slots don't support the extended query protocol.

Instead, we use the `COPY` command from Postgres to dump the table in
question to stdout and parse the output into `sdk.Record` which we then
iterate.

The `CopyDataWriter` will be attached to the `Hybrid` iterator and will handle
the initial capture of a table's data within a transaction.

## Known Issues
We currently cannot handle bytea columns. We are investigating a way for the
CopyDataWriter to handle byte values differently than text values.

Dependency of #43

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
