### PR TITLE
fix: remove reference to unimplemented long polling mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ listens to changes in the configured table. Every detected change is converted i
 `Read`. If there is no record available at the moment `Read` is called, it blocks until a record is available or the
 connector receives a stop signal.
 
-If logical replication isn't available on the PostgreSQL instance, the connector can be configured to use long polling
-by adding `"cdcMode":"longPolling"` to the Source configuration.
-
 ### Logical Replication Configuration
 
 When the connector switches to CDC mode, it attempts to run the initial setup commands to create its logical replication


### PR DESCRIPTION
### Description

Removes references to the unimplemented long polling `cdcMode` from the README.

Fixes # (issue)

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
