### PR TITLE
Upgrade to Go 1.20, remove abandoned linters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: "1.20"
 
       - name: Test
         run: make test GOTEST_FLAGS="-v -count=1"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: "1.20"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.50.1
+          version: v1.51.2
+          args: --timeout=2m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: "1.20"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     # - depguard
     - dogsled
     - durationcheck
@@ -70,7 +69,6 @@ linters:
     - predeclared
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - sqlclosecheck
     # - tagliatelle
@@ -81,7 +79,6 @@ linters:
     - unconvert
     # - unparam
     - unused
-    - varcheck
     - wastedassign
     - whitespace
   # - wrapcheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/conduitio/conduit-connector-postgres
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/squirrel v1.5.3


### PR DESCRIPTION
### Description

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
