### PR TITLE
support reading from multiple tables using logical replication slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,15 @@ returned.
 
 ## Configuration Options
 
-| name                      | description                                                                                                                         | required | default                |
-|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------|----------|------------------------|
-| `url`                     | Connection string for the Postgres database.                                                                                        | true     |                        |
-| `table`                   | List of table names to read from, separated by comma. example: `"employees,offices,payments"`                                       | true     |                        |
-| `snapshotMode`            | Whether or not the plugin will take a snapshot of the entire table before starting cdc mode (allowed values: `initial` or `never`). | false    | `initial`              |
-| `cdcMode`                 | Determines the CDC mode (allowed values: `auto`, `logrepl` or `long_polling`).                                                      | false    | `auto`                 |
-| `logrepl.publicationName` | Name of the publication to listen for WAL events.                                                                                   | false    | `conduitpub`           |
-| `logrepl.slotName`        | Name of the slot opened for replication events.                                                                                     | false    | `conduitslot`          |
+| name                      | description                                                                                                                                                                            | required | default       |
+|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| `url`                     | Connection string for the Postgres database.                                                                                                                                           | true     |               |
+| `table`                   | List of table names to read from, separated by comma. example: `"employees,offices,payments"`                                                                                          | true     |               |
+| `key`                     | List of Key column names per table, separated by comma. example:`"table1:key1,table2:key2"`, if not supplied, the table primary key will be used as the `'Key'` field for the records. | false    |               |
+| `snapshotMode`            | Whether or not the plugin will take a snapshot of the entire table before starting cdc mode (allowed values: `initial` or `never`).                                                    | false    | `initial`     |
+| `cdcMode`                 | Determines the CDC mode (allowed values: `auto`, `logrepl` or `long_polling`).                                                                                                         | false    | `auto`        |
+| `logrepl.publicationName` | Name of the publication to listen for WAL events.                                                                                                                                      | false    | `conduitpub`  |
+| `logrepl.slotName`        | Name of the slot opened for replication events.                                                                                                                                        | false    | `conduitslot` |
 
 # Destination
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ configuration.
 ## Change Data Capture
 
 This connector implements CDC features for PostgreSQL by creating a logical replication slot and a publication that
-listens to changes in the configured table. Every detected change is converted into a record and returned in the call to
+listens to changes in the configured tables. Every detected change is converted into a record and returned in the call to
 `Read`. If there is no record available at the moment `Read` is called, it blocks until a record is available or the
 connector receives a stop signal.
 
@@ -59,11 +59,9 @@ returned.
 ## Configuration Options
 
 | name                      | description                                                                                                                         | required | default                |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------- |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------|----------|------------------------|
 | `url`                     | Connection string for the Postgres database.                                                                                        | true     |                        |
-| `table`                   | The name of the table in Postgres that the connector should read.                                                                   | true     |                        |
-| `columns`                 | Comma separated list of column names that should be included in each Record's payload.                                              | false    | (all columns)          |
-| `key`                     | Column name that records should use for their `Key` fields.                                                                         | false    | (primary key of table) |
+| `table`                   | List of table names to read from, separated by comma. example: `"employees,offices,payments"`                                       | true     |                        |
 | `snapshotMode`            | Whether or not the plugin will take a snapshot of the entire table before starting cdc mode (allowed values: `initial` or `never`). | false    | `initial`              |
 | `cdcMode`                 | Determines the CDC mode (allowed values: `auto`, `logrepl` or `long_polling`).                                                      | false    | `auto`                 |
 | `logrepl.publicationName` | Name of the publication to listen for WAL events.                                                                                   | false    | `conduitpub`           |
@@ -91,7 +89,7 @@ If there is no key, the record will be simply appended.
 ## Configuration Options
 
 | name    | description                                                                 | required | default |
-| ------- | --------------------------------------------------------------------------- | -------- | ------- |
+|---------|-----------------------------------------------------------------------------|----------|---------|
 | `url`   | Connection string for the Postgres database.                                | true     |         |
 | `table` | The name of the table in Postgres that the connector should write to.       | false    |         |
 | `key`   | Column name used to detect if the target table already contains the record. | false    |         |

--- a/source.go
+++ b/source.go
@@ -77,7 +77,7 @@ func (s *Source) Open(ctx context.Context, pos sdk.Position) error {
 			Position:        pos,
 			SlotName:        s.config.LogreplSlotName,
 			PublicationName: s.config.LogreplPublicationName,
-			TableName:       s.config.Table,
+			Tables:          s.config.Table,
 			KeyColumnName:   s.config.Key,
 			Columns:         s.config.Columns,
 		})
@@ -96,7 +96,7 @@ func (s *Source) Open(ctx context.Context, pos sdk.Position) error {
 		snap, err := longpoll.NewSnapshotIterator(
 			ctx,
 			s.conn,
-			s.config.Table,
+			s.config.Table[0], //todo: only the first table for now
 			s.config.Columns,
 			s.config.Key)
 		if err != nil {

--- a/source.go
+++ b/source.go
@@ -64,6 +64,7 @@ func (s *Source) Open(ctx context.Context, pos sdk.Position) error {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	s.conn = conn
+	fmt.Println("COLUMNS: ", columns)
 
 	switch s.config.CDCMode {
 	case source.CDCModeAuto:
@@ -136,7 +137,7 @@ func (s *Source) Teardown(ctx context.Context) error {
 }
 
 func (s *Source) getTableColumns(ctx context.Context, conn *pgx.Conn) ([]string, error) {
-	query := "SELECT column_name FROM information_schema.columns WHERE table_name = ?"
+	query := "SELECT column_name FROM information_schema.columns WHERE table_name = $1"
 
 	rows, err := conn.Query(ctx, query, s.config.Table[0])
 	if err != nil {

--- a/source.go
+++ b/source.go
@@ -30,10 +30,10 @@ import (
 type Source struct {
 	sdk.UnimplementedSource
 
-	iterator    source.Iterator
-	config      source.Config
-	conn        *pgx.Conn
-	KeyColumnMp map[string]string
+	iterator  source.Iterator
+	config    source.Config
+	conn      *pgx.Conn
+	tableKeys map[string]string
 }
 
 func NewSource() sdk.Source {
@@ -58,14 +58,14 @@ func (s *Source) Configure(_ context.Context, cfg map[string]string) error {
 	if len(s.config.Table) != 1 && s.config.CDCMode == source.CDCModeLongPolling {
 		return fmt.Errorf("multi tables are only supported for logrepl CDCMode, please provide only one table")
 	}
-	s.KeyColumnMp = make(map[string]string, len(s.config.Table))
+	s.tableKeys = make(map[string]string, len(s.config.Table))
 	for _, pair := range s.config.Key {
 		// Split each pair into key and value
 		parts := strings.Split(pair, ":")
 		if len(parts) != 2 {
 			return fmt.Errorf("wrong format for the configuration %q, use comma separated pairs of tables and keys, example: table1:key1,table2:key2", "key")
 		}
-		s.KeyColumnMp[parts[0]] = parts[1]
+		s.tableKeys[parts[0]] = parts[1]
 	}
 	return nil
 }
@@ -97,7 +97,7 @@ func (s *Source) Open(ctx context.Context, pos sdk.Position) error {
 			SlotName:        s.config.LogreplSlotName,
 			PublicationName: s.config.LogreplPublicationName,
 			Tables:          s.config.Table,
-			KeyColumnMp:     s.KeyColumnMp,
+			TableKeys:       s.tableKeys,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create logical replication iterator: %w", err)
@@ -116,7 +116,7 @@ func (s *Source) Open(ctx context.Context, pos sdk.Position) error {
 			s.conn,
 			s.config.Table[0], //todo: only the first table for now
 			columns,
-			s.KeyColumnMp[s.config.Table[0]])
+			s.tableKeys[s.config.Table[0]])
 		if err != nil {
 			return fmt.Errorf("failed to create long polling iterator: %w", err)
 		}

--- a/source.go
+++ b/source.go
@@ -17,7 +17,6 @@ package postgres
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/conduitio/conduit-connector-postgres/source"
 	"github.com/conduitio/conduit-connector-postgres/source/logrepl"
@@ -49,23 +48,9 @@ func (s *Source) Configure(_ context.Context, cfg map[string]string) error {
 	if err != nil {
 		return err
 	}
-	// try parsing the url
-	_, err = pgx.ParseConfig(s.config.URL)
+	s.tableKeys, err = s.config.Validate()
 	if err != nil {
-		return fmt.Errorf("invalid url: %w", err)
-	}
-	// todo: when cdcMode "auto" is implemented, change this check
-	if len(s.config.Table) != 1 && s.config.CDCMode == source.CDCModeLongPolling {
-		return fmt.Errorf("multi tables are only supported for logrepl CDCMode, please provide only one table")
-	}
-	s.tableKeys = make(map[string]string, len(s.config.Table))
-	for _, pair := range s.config.Key {
-		// Split each pair into key and value
-		parts := strings.Split(pair, ":")
-		if len(parts) != 2 {
-			return fmt.Errorf("wrong format for the configuration %q, use comma separated pairs of tables and keys, example: table1:key1,table2:key2", "key")
-		}
-		s.tableKeys[parts[0]] = parts[1]
+		return err
 	}
 	return nil
 }

--- a/source.go
+++ b/source.go
@@ -64,7 +64,6 @@ func (s *Source) Open(ctx context.Context, pos sdk.Position) error {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	s.conn = conn
-	fmt.Println("COLUMNS: ", columns)
 
 	switch s.config.CDCMode {
 	case source.CDCModeAuto:

--- a/source/config.go
+++ b/source/config.go
@@ -42,8 +42,8 @@ type Config struct {
 	URL string `json:"url" validate:"required"`
 	// List of table names to read from, separated by a comma.
 	Table []string `json:"table" validate:"required"`
-	// todo: remove param, Column name that records should use for their `Key` fields.
-	Key string `json:"key"`
+	// list of Key column names per table ex:"table1:key1,table2:key2", records should use the key values for their `Key` fields.
+	Key []string `json:"key"`
 
 	// Whether or not the plugin will take a snapshot of the entire table before starting cdc mode.
 	SnapshotMode SnapshotMode `json:"snapshotMode" validate:"inclusion=initial|never" default:"initial"`

--- a/source/config.go
+++ b/source/config.go
@@ -42,8 +42,6 @@ type Config struct {
 	URL string `json:"url" validate:"required"`
 	// List of table names to read from, separated by a comma.
 	Table []string `json:"table" validate:"required"`
-	// todo: reove param, Comma separated list of column names that should be included in each Record's payload.
-	Columns []string `json:"columns"`
 	// todo: remove param, Column name that records should use for their `Key` fields.
 	Key string `json:"key"`
 

--- a/source/config.go
+++ b/source/config.go
@@ -40,12 +40,12 @@ const (
 type Config struct {
 	// URL is the connection string for the Postgres database.
 	URL string `json:"url" validate:"required"`
-	// List of table names to read from, separated by a comma.
+	// Table is a List of table names to read from, separated by a comma.
 	Table []string `json:"table" validate:"required"`
-	// list of Key column names per table ex:"table1:key1,table2:key2", records should use the key values for their `Key` fields.
+	// Key is a list of Key column names per table, ex:"table1:key1,table2:key2", records should use the key values for their `Key` fields.
 	Key []string `json:"key"`
 
-	// Whether or not the plugin will take a snapshot of the entire table before starting cdc mode.
+	// SnapshotMode is whether the plugin will take a snapshot of the entire table before starting cdc mode.
 	SnapshotMode SnapshotMode `json:"snapshotMode" validate:"inclusion=initial|never" default:"initial"`
 	// CDCMode determines how the connector should listen to changes.
 	CDCMode CDCMode `json:"cdcMode" validate:"inclusion=auto|logrepl|long_polling" default:"auto"`

--- a/source/config.go
+++ b/source/config.go
@@ -40,11 +40,11 @@ const (
 type Config struct {
 	// URL is the connection string for the Postgres database.
 	URL string `json:"url" validate:"required"`
-	// The name of the table in Postgres that the connector should read.
-	Table string `json:"table" validate:"required"`
-	// Comma separated list of column names that should be included in each Record's payload.
+	// List of table names to read from, separated by a comma.
+	Table []string `json:"table" validate:"required"`
+	// todo: reove param, Comma separated list of column names that should be included in each Record's payload.
 	Columns []string `json:"columns"`
-	// Column name that records should use for their `Key` fields.
+	// todo: remove param, Column name that records should use for their `Key` fields.
 	Key string `json:"key"`
 
 	// Whether or not the plugin will take a snapshot of the entire table before starting cdc mode.

--- a/source/config_test.go
+++ b/source/config_test.go
@@ -15,7 +15,6 @@
 package source
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/matryer/is"
@@ -68,7 +67,6 @@ func TestConfig_Validate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			is := is.New(t)
 			_, err := tc.cfg.Validate()
-			fmt.Println(err)
 			if tc.wantErr {
 				is.True(err != nil)
 				return

--- a/source/config_test.go
+++ b/source/config_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2023 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{{
+		name: "valid config",
+		cfg: Config{
+			URL:     "postgresql://meroxauser:meroxapass@127.0.0.1:5432/meroxadb",
+			Table:   []string{"table1", "table2"},
+			Key:     []string{"table1:key1"},
+			CDCMode: CDCModeLogrepl,
+		},
+		wantErr: false,
+	}, {
+		name: "invalid postgres url",
+		cfg: Config{
+			URL:     "postgresql",
+			Table:   []string{"table1", "table2"},
+			Key:     []string{"table1:key1"},
+			CDCMode: CDCModeLogrepl,
+		},
+		wantErr: true,
+	}, {
+		name: "invalid multiple tables for long polling",
+		cfg: Config{
+			URL:     "postgresql://meroxauser:meroxapass@127.0.0.1:5432/meroxadb",
+			Table:   []string{"table1", "table2"},
+			Key:     []string{"table1:key1"},
+			CDCMode: CDCModeLongPolling,
+		},
+		wantErr: true,
+	}, {
+		name: "invalid key list format",
+		cfg: Config{
+			URL:     "postgresql://meroxauser:meroxapass@127.0.0.1:5432/meroxadb",
+			Table:   []string{"table1", "table2"},
+			Key:     []string{"key1,key2"},
+			CDCMode: CDCModeLogrepl,
+		},
+		wantErr: true,
+	},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			_, err := tc.cfg.Validate()
+			fmt.Println(err)
+			if tc.wantErr {
+				is.True(err != nil)
+				return
+			}
+			is.True(err == nil)
+		})
+	}
+}

--- a/source/logrepl/cdc.go
+++ b/source/logrepl/cdc.go
@@ -38,7 +38,6 @@ type Config struct {
 	PublicationName string
 	Tables          []string
 	KeyColumnName   string
-	Columns         []string
 }
 
 // CDCIterator asynchronously listens for events from the logical replication
@@ -173,7 +172,6 @@ func (i *CDCIterator) attachSubscription(ctx context.Context, conn *pgx.Conn) er
 		NewCDCHandler(
 			internal.NewRelationSet(conn.ConnInfo()),
 			keyColumnMp,
-			i.config.Columns, // todo, delete this option, use processors instead
 			i.records,
 		).Handle,
 	)

--- a/source/logrepl/cdc_test.go
+++ b/source/logrepl/cdc_test.go
@@ -137,7 +137,7 @@ func TestIterator_Next(t *testing.T) {
 func testIterator(ctx context.Context, t *testing.T, pool *pgxpool.Pool, table string) *CDCIterator {
 	is := is.New(t)
 	config := Config{
-		TableName:       table,
+		Tables:          []string{table},
 		PublicationName: table, // table is random, reuse for publication name
 		SlotName:        table, // table is random, reuse for slot name
 	}

--- a/source/logrepl/handler.go
+++ b/source/logrepl/handler.go
@@ -27,18 +27,18 @@ import (
 // CDCHandler is responsible for handling logical replication messages,
 // converting them to a record and sending them to a channel.
 type CDCHandler struct {
-	keyColumnMp map[string]string
+	tableKeys   map[string]string
 	relationSet *internal.RelationSet
 	out         chan<- sdk.Record
 }
 
 func NewCDCHandler(
 	rs *internal.RelationSet,
-	keyColumnMp map[string]string,
+	tableKeys map[string]string,
 	out chan<- sdk.Record,
 ) *CDCHandler {
 	return &CDCHandler{
-		keyColumnMp: keyColumnMp,
+		tableKeys:   tableKeys,
 		relationSet: rs,
 		out:         out,
 	}
@@ -181,7 +181,7 @@ func (h *CDCHandler) buildRecordMetadata(relation *pglogrepl.RelationMessage) ma
 // buildRecordKey takes the values from the message and extracts the key that
 // matches the configured keyColumnName.
 func (h *CDCHandler) buildRecordKey(values map[string]pgtype.Value, table string) sdk.Data {
-	keyColumn := h.keyColumnMp[table]
+	keyColumn := h.tableKeys[table]
 	key := make(sdk.StructuredData)
 	for k, v := range values {
 		if keyColumn == k {

--- a/source/logrepl/handler.go
+++ b/source/logrepl/handler.go
@@ -200,8 +200,7 @@ func (h *CDCHandler) buildRecordPayload(values map[string]pgtype.Value) sdk.Data
 	}
 	payload := make(sdk.StructuredData)
 	for k, v := range values {
-		value := v.Get()
-		payload[k] = value
+		payload[k] = v.Get()
 	}
 	return payload
 }

--- a/source/logrepl/handler.go
+++ b/source/logrepl/handler.go
@@ -28,7 +28,6 @@ import (
 // converting them to a record and sending them to a channel.
 type CDCHandler struct {
 	keyColumnMp map[string]string
-	columns     map[string]bool // columns can be used to filter only specific columns
 	relationSet *internal.RelationSet
 	out         chan<- sdk.Record
 }
@@ -36,19 +35,10 @@ type CDCHandler struct {
 func NewCDCHandler(
 	rs *internal.RelationSet,
 	keyColumnMp map[string]string,
-	columns []string,
 	out chan<- sdk.Record,
 ) *CDCHandler {
-	var columnSet map[string]bool
-	if len(columns) > 0 {
-		columnSet = make(map[string]bool)
-		for _, col := range columns {
-			columnSet[col] = true
-		}
-	}
 	return &CDCHandler{
 		keyColumnMp: keyColumnMp,
-		columns:     columnSet,
 		relationSet: rs,
 		out:         out,
 	}
@@ -210,11 +200,8 @@ func (h *CDCHandler) buildRecordPayload(values map[string]pgtype.Value) sdk.Data
 	}
 	payload := make(sdk.StructuredData)
 	for k, v := range values {
-		// filter columns if columns are specified
-		if h.columns == nil || h.columns[k] {
-			value := v.Get()
-			payload[k] = value
-		}
+		value := v.Get()
+		payload[k] = value
 	}
 	return payload
 }

--- a/source/logrepl/internal/subscription.go
+++ b/source/logrepl/internal/subscription.go
@@ -305,7 +305,6 @@ func (s *Subscription) createPublication(ctx context.Context, conn *pgconn.PgCon
 		conn,
 		s.Publication,
 		CreatePublicationOptions{Tables: s.Tables},
-		//CreatePublicationOptions{AllTables: true},
 	); err != nil {
 		// If creating the publication fails with code 42710, this means
 		// the publication already exists.

--- a/source/logrepl/internal/subscription.go
+++ b/source/logrepl/internal/subscription.go
@@ -305,6 +305,7 @@ func (s *Subscription) createPublication(ctx context.Context, conn *pgconn.PgCon
 		conn,
 		s.Publication,
 		CreatePublicationOptions{Tables: s.Tables},
+		//CreatePublicationOptions{AllTables: true},
 	); err != nil {
 		// If creating the publication fails with code 42710, this means
 		// the publication already exists.

--- a/source/longpoll/snapshot.go
+++ b/source/longpoll/snapshot.go
@@ -72,7 +72,7 @@ type SnapshotIterator struct {
 // * NewSnapshotIterator attempts to load the sql rows into the SnapshotIterator and will
 // immediately begin to return them to subsequent Read calls.
 // * It acquires a read only transaction lock before reading the table.
-// * If Teardown is called while a snpashot is in progress, it will return an
+// * If Teardown is called while a snapshot is in progress, it will return an
 // ErrSnapshotInterrupt error.
 func NewSnapshotIterator(ctx context.Context, conn *pgx.Conn, table string, columns []string, key string) (*SnapshotIterator, error) {
 	s := &SnapshotIterator{

--- a/source/paramgen.go
+++ b/source/paramgen.go
@@ -19,13 +19,13 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"columns": {
 			Default:     "",
-			Description: "Comma separated list of column names that should be included in each Record's payload.",
+			Description: "todo: reove param, Comma separated list of column names that should be included in each Record's payload.",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{},
 		},
 		"key": {
 			Default:     "",
-			Description: "Column name that records should use for their `key` fields.",
+			Description: "todo: remove param, Column name that records should use for their `key` fields.",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{},
 		},
@@ -51,7 +51,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"table": {
 			Default:     "",
-			Description: "The name of the table in Postgres that the connector should read.",
+			Description: "List of table names to read from, separated by a comma.",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},

--- a/source/paramgen.go
+++ b/source/paramgen.go
@@ -17,12 +17,6 @@ func (Config) Parameters() map[string]sdk.Parameter {
 				sdk.ValidationInclusion{List: []string{"auto", "logrepl", "long_polling"}},
 			},
 		},
-		"columns": {
-			Default:     "",
-			Description: "todo: reove param, Comma separated list of column names that should be included in each Record's payload.",
-			Type:        sdk.ParameterTypeString,
-			Validations: []sdk.Validation{},
-		},
 		"key": {
 			Default:     "",
 			Description: "todo: remove param, Column name that records should use for their `key` fields.",


### PR DESCRIPTION
### Description
  
support reading from multiple tables using logical replication slots.

changes to params:
* "columns" param is removed.
* "key" param is updates now to accept multiple tables and keys, as a list of pairs, example: "table1:key1,table2:key2", if the key is not provided, we'll fetch the table's primary key.

Fixes #23 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
