### PR TITLE
Add default logrepl autoCleanup mode to remove replication slots and publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ the connector will return an error.
 | `cdcMode`                 | Determines the CDC mode (allowed values: `auto`, `logrepl` or `long_polling`).                                                             | false    | `auto`        |
 | `logrepl.publicationName` | Name of the publication to listen for WAL events.                                                                                          | false    | `conduitpub`  |
 | `logrepl.slotName`        | Name of the slot opened for replication events.                                                                                            | false    | `conduitslot` |
+| `logrepl.autoCleanup`     | Whether or not to cleanup the replication slot and pub when connector is deleted                                                                                            | false    | `true` |
 | ~~`table`~~               | List of table names to read from, separated by comma. **Deprecated: use `tables` instead.**                                                | false    |               |
 
 # Destination

--- a/source/config.go
+++ b/source/config.go
@@ -68,6 +68,10 @@ type Config struct {
 	// LogreplSlotName determines the replication slot name in case the
 	// connector uses logical replication to listen to changes (see CDCMode).
 	LogreplSlotName string `json:"logrepl.slotName" default:"conduitslot"`
+
+	// LogreplAutoCleanup determines if the replication slot and publication should be
+	// removed when the connector is deleted.
+	LogreplAutoCleanup bool `json:"logrepl.autoCleanup" validate:"inclusion=true|t,exclusion=false|f" default:"true"`
 }
 
 // Validate validates the provided config values.

--- a/source/logrepl/cleaner.go
+++ b/source/logrepl/cleaner.go
@@ -1,0 +1,83 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logrepl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/conduitio/conduit-connector-postgres/source/logrepl/internal"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type CleanupConfig struct {
+	URL             string
+	SlotName        string
+	PublicationName string
+}
+
+// Cleanup drops the provided replication and publication.
+func Cleanup(ctx context.Context, c CleanupConfig) error {
+	pgconfig, err := pgconn.ParseConfig(c.URL)
+	if err != nil {
+		return fmt.Errorf("failed to parse config URL: %w", err)
+	}
+
+	if pgconfig.RuntimeParams == nil {
+		pgconfig.RuntimeParams = make(map[string]string)
+	}
+	pgconfig.RuntimeParams["replication"] = "database"
+
+	conn, err := pgconn.ConnectConfig(ctx, pgconfig)
+	if err != nil {
+		return fmt.Errorf("could not establish replication connection: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	var errs []error
+
+	if c.SlotName != "" {
+		if err := pglogrepl.DropReplicationSlot(
+			ctx,
+			conn,
+			c.SlotName,
+			pglogrepl.DropReplicationSlotOptions{},
+		); err != nil {
+			errs = append(errs, fmt.Errorf("failed to clean up replication slot %q: %w", c.SlotName, err))
+		}
+	} else {
+		sdk.Logger(ctx).Warn().
+			Msg("cleanup: skipping replication slot cleanup, name is empty")
+	}
+
+	if c.PublicationName != "" {
+		if err := internal.DropPublication(
+			ctx,
+			conn,
+			c.PublicationName,
+			internal.DropPublicationOptions{IfExists: true},
+		); err != nil {
+			errs = append(errs, fmt.Errorf("failed to clean up publication %q: %w", c.PublicationName, err))
+		}
+	} else {
+		sdk.Logger(ctx).Warn().
+			Msg("cleanup: skipping publication cleanup, name is empty")
+	}
+
+	return errors.Join(errs...)
+}

--- a/source/logrepl/cleaner_test.go
+++ b/source/logrepl/cleaner_test.go
@@ -1,0 +1,111 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logrepl
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit-connector-postgres/test"
+	"github.com/matryer/is"
+)
+
+func Test_Cleanup(t *testing.T) {
+	conn := test.ConnectSimple(context.Background(), t, test.RepmgrConnString)
+
+	tests := []struct {
+		desc  string
+		setup func(t *testing.T)
+		conf  CleanupConfig
+
+		wantErr error
+	}{
+		{
+			desc: "drops slot and pub",
+			conf: CleanupConfig{
+				URL:             test.RepmgrConnString,
+				SlotName:        "conduitslot",
+				PublicationName: "conduitpub",
+			},
+			setup: func(t *testing.T) {
+				test.CreatePublication(t, conn, "conduitpub")
+				test.CreateReplicationSlot(t, conn, "conduitslot")
+			},
+		},
+		{
+			desc: "drops pub, slot unspecified",
+			conf: CleanupConfig{
+				URL:             test.RepmgrConnString,
+				PublicationName: "conduitpub",
+			},
+			setup: func(t *testing.T) {
+				test.CreatePublication(t, conn, "conduitpub")
+			},
+		},
+		{
+			desc: "drops slot, pub unspecified",
+			conf: CleanupConfig{
+				URL:      test.RepmgrConnString,
+				SlotName: "conduitslot",
+			},
+			setup: func(t *testing.T) {
+				test.CreateReplicationSlot(t, conn, "conduitslot")
+			},
+		},
+		{
+			desc: "drops pub, slot missing",
+			conf: CleanupConfig{
+				URL:             test.RepmgrConnString,
+				SlotName:        "conduitslot",
+				PublicationName: "conduitpub",
+			},
+			setup: func(t *testing.T) {
+				test.CreatePublication(t, conn, "conduitpub")
+			},
+			wantErr: errors.New(`replication slot "conduitslot" does not exist`),
+		},
+		{
+			desc: "drops slot, pub missing", // no op
+			conf: CleanupConfig{
+				URL:             test.RepmgrConnString,
+				SlotName:        "conduitslot",
+				PublicationName: "conduitpub",
+			},
+			setup: func(t *testing.T) {
+				test.CreateReplicationSlot(t, conn, "conduitslot")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			is := is.New(t)
+
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+
+			err := Cleanup(context.Background(), tc.conf)
+
+			if tc.wantErr != nil {
+				is.True(strings.Contains(err.Error(), tc.wantErr.Error()))
+			} else {
+				is.NoErr(err)
+			}
+		})
+	}
+}

--- a/source/logrepl/internal/subscription.go
+++ b/source/logrepl/internal/subscription.go
@@ -312,16 +312,8 @@ func (s *Subscription) createPublication(ctx context.Context, conn *pgconn.PgCon
 		if !errors.As(err, &pgerr) || pgerr.Code != pgDuplicateObjectErrorCode {
 			return err
 		}
-	} else {
-		// publication was created successfully, drop it when we're done
-		s.addCleanup(func(ctx context.Context) error {
-			err := DropPublication(ctx, conn, s.Publication, DropPublicationOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to drop publication: %w", err)
-			}
-			return nil
-		})
 	}
+
 	return nil
 }
 
@@ -335,7 +327,6 @@ func (s *Subscription) createReplicationSlot(ctx context.Context, conn *pgconn.P
 		s.SlotName,
 		pgOutputPlugin,
 		pglogrepl.CreateReplicationSlotOptions{
-			Temporary:      true, // replication slot is dropped when we disconnect
 			SnapshotAction: "EXPORT_SNAPSHOT",
 			Mode:           pglogrepl.LogicalReplication,
 		},

--- a/source/paramgen.go
+++ b/source/paramgen.go
@@ -17,6 +17,15 @@ func (Config) Parameters() map[string]sdk.Parameter {
 				sdk.ValidationInclusion{List: []string{"auto", "logrepl", "long_polling"}},
 			},
 		},
+		"logrepl.autoCleanup": {
+			Default:     "true",
+			Description: "logrepl.autoCleanup determines if the replication slot and publication should be removed when the connector is deleted.",
+			Type:        sdk.ParameterTypeBool,
+			Validations: []sdk.Validation{
+				sdk.ValidationInclusion{List: []string{"true", "t"}},
+				sdk.ValidationExclusion{List: []string{"false", "f"}},
+			},
+		},
 		"logrepl.publicationName": {
 			Default:     "conduitpub",
 			Description: "logrepl.publicationName determines the publication name in case the connector uses logical replication to listen to changes (see CDCMode).",

--- a/test/helper.go
+++ b/test/helper.go
@@ -99,6 +99,27 @@ func SetupTestTable(ctx context.Context, t *testing.T, conn Querier) string {
 	return table
 }
 
+func CreateReplicationSlot(t *testing.T, conn *pgx.Conn, slotName string) {
+	is := is.New(t)
+
+	_, err := conn.Exec(
+		context.Background(),
+		"SELECT pg_create_logical_replication_slot($1, $2)",
+		slotName,
+		"pgoutput",
+	)
+
+	is.NoErr(err)
+}
+
+func CreatePublication(t *testing.T, conn *pgx.Conn, pubName string) {
+	is := is.New(t)
+
+	_, err := conn.Exec(context.Background(), "CREATE PUBLICATION "+pubName+" FOR ALL TABLES")
+
+	is.NoErr(err)
+}
+
 func RandomIdentifier(t *testing.T) string {
 	return fmt.Sprintf("conduit_%v_%d",
 		strings.ReplaceAll(strings.ToLower(t.Name()), "/", "_"),


### PR DESCRIPTION
### Description

The new option `logrepl.autoCleanup` is not only valid in the context of logical replication. The default is set to true and will remove the replication slot and publication when the connector is deleted.

This change is a departure from the current implementation, in the following areas:

1. Replication slots are not `temporary` any longer and will persist through pipeline state changes.
2. An implication of 1) the slot will need to be cleaned up, hence why the `autoCleanup` option is set to true.

In cases where the replication slots and publications are pre-created, ensure `logrepl.autoCleanup` is set to `false`.

Fixes # (issue)

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
