### PR TITLE
Add missing initialization for tableKeys field

### DIFF
--- a/source.go
+++ b/source.go
@@ -55,6 +55,8 @@ func (s *Source) Configure(_ context.Context, cfg map[string]string) error {
 
 	s.config = s.config.Init()
 
+	s.tableKeys = make(map[string]string)
+
 	return s.config.Validate()
 }
 

--- a/source.go
+++ b/source.go
@@ -40,7 +40,12 @@ type Source struct {
 }
 
 func NewSource() sdk.Source {
-	return sdk.SourceWithMiddleware(&Source{}, sdk.DefaultSourceMiddleware()...)
+	return sdk.SourceWithMiddleware(
+		&Source{
+			tableKeys: make(map[string]string),
+		},
+		sdk.DefaultSourceMiddleware()...,
+	)
 }
 
 func (s *Source) Parameters() map[string]sdk.Parameter {
@@ -54,8 +59,6 @@ func (s *Source) Configure(_ context.Context, cfg map[string]string) error {
 	}
 
 	s.config = s.config.Init()
-
-	s.tableKeys = make(map[string]string)
 
 	return s.config.Validate()
 }

--- a/source_integration_test.go
+++ b/source_integration_test.go
@@ -1,0 +1,49 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/conduitio/conduit-connector-postgres/test"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+	"github.com/jackc/pgx/v5"
+	"github.com/matryer/is"
+)
+
+func TestSource_Open(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	conn := test.ConnectSimple(ctx, t, test.RegularConnString)
+	tableName := test.SetupTestTable(ctx, t, conn)
+
+	s := NewSource()
+	err := s.Configure(
+		ctx,
+		map[string]string{
+			"url":   test.RegularConnString,
+			"table": "{{ index .Metadata \"opencdc.collection\" }}",
+		},
+	)
+	is.NoErr(err)
+	err = s.Open(ctx)
+	is.NoErr(err)
+	defer func() {
+		err := s.Teardown(ctx)
+		is.NoErr(err)
+	}()
+}

--- a/source_integration_test.go
+++ b/source_integration_test.go
@@ -16,12 +16,9 @@ package postgres
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/conduitio/conduit-connector-postgres/test"
-	sdk "github.com/conduitio/conduit-connector-sdk"
-	"github.com/jackc/pgx/v5"
 	"github.com/matryer/is"
 )
 
@@ -35,15 +32,18 @@ func TestSource_Open(t *testing.T) {
 	err := s.Configure(
 		ctx,
 		map[string]string{
-			"url":   test.RegularConnString,
-			"table": "{{ index .Metadata \"opencdc.collection\" }}",
+			"url":          test.RegularConnString,
+			"tables":       tableName,
+			"cdcMode":      "long_polling",
+			"snapshotMode": "initial",
 		},
 	)
 	is.NoErr(err)
-	err = s.Open(ctx)
+
+	err = s.Open(ctx, nil)
 	is.NoErr(err)
+
 	defer func() {
-		err := s.Teardown(ctx)
-		is.NoErr(err)
+		is.NoErr(s.Teardown(ctx))
 	}()
 }


### PR DESCRIPTION
13d4cad refactored Configure(), but in the process failed to initialize the tableKeys field, which ends up panic()ing due to an uninitialized map when scanning the table primary keys.

This commit fixes this. :)

### Description

Please include a summary of the change and what type of change it is (new feature, bug fix, refactoring, documentation).
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
