### PR TITLE
Ensure defaults for publication, slot, auto-cleanup are available to lifecycle events.

### DIFF
--- a/source/config.go
+++ b/source/config.go
@@ -57,6 +57,10 @@ type Config struct {
 
 	// SnapshotMode is whether the plugin will take a snapshot of the entire table before starting cdc mode.
 	SnapshotMode SnapshotMode `json:"snapshotMode" validate:"inclusion=initial|never" default:"initial"`
+
+	// Snapshot fetcher size determines the number of rows to retrieve at a time.
+	SnapshotFetchSize int `json:"snapshot.fetchSize" default:"50000"`
+
 	// CDCMode determines how the connector should listen to changes.
 	CDCMode CDCMode `json:"cdcMode" validate:"inclusion=auto|logrepl" default:"auto"`
 

--- a/source/logrepl/combined.go
+++ b/source/logrepl/combined.go
@@ -41,12 +41,13 @@ type CombinedIterator struct {
 }
 
 type Config struct {
-	Position        sdk.Position
-	SlotName        string
-	PublicationName string
-	Tables          []string
-	TableKeys       map[string]string
-	WithSnapshot    bool
+	Position          sdk.Position
+	SlotName          string
+	PublicationName   string
+	Tables            []string
+	TableKeys         map[string]string
+	WithSnapshot      bool
+	SnapshotFetchSize int
 }
 
 // Validate performs validation tasks on the config.
@@ -201,6 +202,7 @@ func (c *CombinedIterator) initSnapshotIterator(ctx context.Context, pos positio
 		Tables:       c.conf.Tables,
 		TableKeys:    c.conf.TableKeys,
 		TXSnapshotID: c.cdcIterator.TXSnapshotID(),
+		FetchSize:    c.conf.SnapshotFetchSize,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot iterator: %w", err)

--- a/source/paramgen.go
+++ b/source/paramgen.go
@@ -35,6 +35,12 @@ func (Config) Parameters() map[string]sdk.Parameter {
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{},
 		},
+		"snapshot.fetchSize": {
+			Default:     "50000",
+			Description: "Snapshot fetcher size determines the number of rows to retrieve at a time.",
+			Type:        sdk.ParameterTypeInt,
+			Validations: []sdk.Validation{},
+		},
 		"snapshotMode": {
 			Default:     "initial",
 			Description: "snapshotMode is whether the plugin will take a snapshot of the entire table before starting cdc mode.",

--- a/source/snapshot/fetch_worker.go
+++ b/source/snapshot/fetch_worker.go
@@ -169,6 +169,13 @@ func (f *FetchWorker) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to update fetch limit: %w", err)
 	}
 
+	sdk.Logger(ctx).Info().
+		Int("fetchSize", f.conf.FetchSize).
+		Str("tx.snapshot", f.conf.TXSnapshotID).
+		Int64("startAt", f.lastRead).
+		Int64("snapshotEnd", f.snapshotEnd).
+		Msgf("starting fetcher %s", f.cursorName)
+
 	closeCursor, err := f.createCursor(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("failed to create cursor: %w", err)

--- a/source/snapshot/iterator.go
+++ b/source/snapshot/iterator.go
@@ -33,6 +33,7 @@ type Config struct {
 	Tables       []string
 	TableKeys    map[string]string
 	TXSnapshotID string
+	FetchSize    int
 }
 
 type Iterator struct {
@@ -132,6 +133,7 @@ func (i *Iterator) initFetchers(ctx context.Context) error {
 			Key:          i.conf.TableKeys[t],
 			TXSnapshotID: i.conf.TXSnapshotID,
 			Position:     i.lastPosition,
+			FetchSize:    i.conf.FetchSize,
 		})
 
 		if err := w.Validate(ctx); err != nil {


### PR DESCRIPTION
### Description

Add config for snapshot fetch size.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
