### PR TITLE
Improve handling of keepalive messages and manage server end lag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 .PHONY: test
 test:
 	# run required docker containers, execute integration tests, stop containers after tests
-	docker compose -f test/docker-compose.yml up --quiet-pull -d --wait
+	docker compose -f test/docker-compose.yml up --force-recreate --quiet-pull -d --wait
 	go test $(GOTEST_FLAGS) -race ./...; ret=$$?; \
 		docker compose -f test/docker-compose.yml down --volumes; \
 		exit $$ret

--- a/source/logrepl/combined_test.go
+++ b/source/logrepl/combined_test.go
@@ -211,7 +211,6 @@ func TestCombinedIterator_Next(t *testing.T) {
 
 	t.Run("next_connector_resume_cdc_6", func(t *testing.T) {
 		is := is.New(t)
-
 		i, err := NewCombinedIterator(ctx, pool, Config{
 			Position:        lastPos,
 			Tables:          []string{table},

--- a/source/logrepl/internal/subscription.go
+++ b/source/logrepl/internal/subscription.go
@@ -351,7 +351,7 @@ func (s *Subscription) sendStandbyStatusUpdate(ctx context.Context) error {
 
 	// N.B. Manage replication slot lag, by responding with the last server LSN, when
 	//      all previous slot relevant msgs have been written and flushed
-	if walFlushed == s.walWritten && s.walFlushed < s.serverWALEnd {
+	if walFlushed == s.walWritten && walFlushed < s.serverWALEnd {
 		if err := pglogrepl.SendStandbyStatusUpdate(ctx, s.conn, pglogrepl.StandbyStatusUpdate{
 			WALWritePosition: s.serverWALEnd,
 			ClientTime:       time.Now(),

--- a/source/logrepl/internal/subscription.go
+++ b/source/logrepl/internal/subscription.go
@@ -160,13 +160,11 @@ func (s *Subscription) listen(ctx context.Context) error {
 
 		switch copyDataMsg.Data[0] {
 		case pglogrepl.PrimaryKeepaliveMessageByteID:
-			err := s.handlePrimaryKeepaliveMessage(ctx, copyDataMsg)
-			if err != nil {
+			if err := s.handlePrimaryKeepaliveMessage(ctx, copyDataMsg); err != nil {
 				return err
 			}
 		case pglogrepl.XLogDataByteID:
-			err := s.handleXLogData(ctx, copyDataMsg)
-			if err != nil {
+			if err := s.handleXLogData(ctx, copyDataMsg); err != nil {
 				return err
 			}
 		default:
@@ -187,7 +185,7 @@ func (s *Subscription) handlePrimaryKeepaliveMessage(ctx context.Context, copyDa
 		return fmt.Errorf("failed to parse primary keepalive message: %w", err)
 	}
 
-	s.serverWALEnd = pkm.ServerWALEnd
+	atomic.StoreUint64((*uint64)(&s.serverWALEnd), uint64(pkm.ServerWALEnd))
 
 	if pkm.ReplyRequested {
 		if err := s.sendStandbyStatusUpdate(ctx); err != nil {

--- a/source/logrepl/internal/subscription.go
+++ b/source/logrepl/internal/subscription.go
@@ -338,6 +338,8 @@ func (s *Subscription) sendStandbyStatusUpdate(ctx context.Context) error {
 		}); err != nil {
 			return fmt.Errorf("failed to send standby status update with server end lsn: %w", err)
 		}
+
+		return nil
 	}
 
 	if err := pglogrepl.SendStandbyStatusUpdate(ctx, s.conn, pglogrepl.StandbyStatusUpdate{

--- a/source/logrepl/internal/subscription_test.go
+++ b/source/logrepl/internal/subscription_test.go
@@ -233,12 +233,12 @@ func setupSubscription(
 		publication,
 		tables,
 		0,
-		func(ctx context.Context, msg pglogrepl.Message, _ pglogrepl.LSN) error {
+		func(ctx context.Context, msg pglogrepl.Message, lsn pglogrepl.LSN) (pglogrepl.LSN, error) {
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return 0, ctx.Err()
 			case messages <- msg:
-				return nil
+				return lsn, nil
 			}
 		},
 	)

--- a/source/logrepl/internal/subscription_test.go
+++ b/source/logrepl/internal/subscription_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -46,7 +47,7 @@ func TestSubscription_WithRepmgr(t *testing.T) {
 	table1 := test.SetupTestTable(ctx, t, conn)
 	table2 := test.SetupTestTable(ctx, t, conn)
 
-	_, messages := setupSubscription(ctx, t, replConn, table1, table2)
+	sub, messages := setupSubscription(ctx, t, replConn, table1, table2)
 
 	fetchAndAssertMessageTypes := func(is *is.I, m chan pglogrepl.Message, msgTypes ...pglogrepl.MessageType) []pglogrepl.Message {
 		out := make([]pglogrepl.Message, len(msgTypes))
@@ -131,6 +132,17 @@ func TestSubscription_WithRepmgr(t *testing.T) {
 			pglogrepl.MessageTypeUpdate,
 			pglogrepl.MessageTypeCommit,
 		)
+	})
+
+	t.Run("Last WAL written is behind keepalive", func(t *testing.T) {
+		is := is.New(t)
+
+		is.Equal(sub.walFlushed, pglogrepl.LSN(0)) // no acks
+
+		time.Sleep(500 * time.Millisecond) // Server may sent these every 200ms or so.
+
+		serverWALEnd := pglogrepl.LSN(atomic.LoadUint64((*uint64)(&sub.serverWALEnd)))
+		is.True(serverWALEnd > sub.walWritten)
 	})
 
 	t.Run("no more messages", func(t *testing.T) {


### PR DESCRIPTION
### Description

* Ensure expected commit lsn matches that of begin messages.
* Adjust the status update to send the last server lsn when all data nas been written and acked. This change will help with managing server lag with relatively less frequently updated tables.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
