### PR TITLE
Add support for reading replication slot

### DIFF
--- a/source.go
+++ b/source.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/conduitio/conduit-commons/csync"
 	"github.com/conduitio/conduit-connector-postgres/source"
+	"github.com/conduitio/conduit-connector-postgres/source/cpool"
 	"github.com/conduitio/conduit-connector-postgres/source/logrepl"
-	cpool "github.com/conduitio/conduit-connector-postgres/source/pool"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"

--- a/source.go
+++ b/source.go
@@ -23,6 +23,7 @@ import (
 	"github.com/conduitio/conduit-commons/csync"
 	"github.com/conduitio/conduit-connector-postgres/source"
 	"github.com/conduitio/conduit-connector-postgres/source/logrepl"
+	cpool "github.com/conduitio/conduit-connector-postgres/source/pool"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -63,7 +64,7 @@ func (s *Source) Configure(_ context.Context, cfg map[string]string) error {
 }
 
 func (s *Source) Open(ctx context.Context, pos sdk.Position) error {
-	pool, err := pgxpool.New(ctx, s.config.URL)
+	pool, err := cpool.New(ctx, s.config.URL)
 	if err != nil {
 		return fmt.Errorf("failed to create a connection pool to database: %w", err)
 	}

--- a/source/cpool/cpool.go
+++ b/source/cpool/cpool.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pool
+package cpool
 
 import (
 	"context"
@@ -51,7 +51,7 @@ func New(ctx context.Context, conninfo string) (*pgxpool.Pool, error) {
 // * If a replication connection is requested, ensure the connection has replication enabled.
 // * If a regular connection is requested, return non-replication connections.
 func beforeAcquireHook(ctx context.Context, conn *pgx.Conn) bool {
-	replReq := ctx.Value(WithReplCtxKey) != nil
+	replReq := ctx.Value(replicationCtxKey{}) != nil
 	replOn := conn.Config().RuntimeParams["replication"] != ""
 
 	return replReq == replOn
@@ -59,7 +59,7 @@ func beforeAcquireHook(ctx context.Context, conn *pgx.Conn) bool {
 
 // beforeConnectHook customizes the configuration of the new connection.
 func beforeConnectHook(ctx context.Context, config *pgx.ConnConfig) error {
-	if v := ctx.Value(WithReplCtxKey); v != nil {
+	if v := ctx.Value(replicationCtxKey{}); v != nil {
 		config.RuntimeParams["replication"] = "database"
 	}
 

--- a/source/logrepl/combined.go
+++ b/source/logrepl/combined.go
@@ -171,7 +171,7 @@ func (c *CombinedIterator) initCDCIterator(ctx context.Context, pos position.Pos
 		return fmt.Errorf("failed to parse LSN in position: %w", err)
 	}
 
-	cdcIterator, err := NewCDCIterator(ctx, &c.pool.Config().ConnConfig.Config, CDCConfig{
+	cdcIterator, err := NewCDCIterator(ctx, c.pool, CDCConfig{
 		LSN:             lsn,
 		SlotName:        c.conf.SlotName,
 		PublicationName: c.conf.PublicationName,

--- a/source/logrepl/combined_test.go
+++ b/source/logrepl/combined_test.go
@@ -137,7 +137,7 @@ func TestCombinedIterator_New(t *testing.T) {
 }
 
 func TestCombinedIterator_Next(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
 	is := is.New(t)
@@ -220,6 +220,7 @@ func TestCombinedIterator_Next(t *testing.T) {
 			WithSnapshot:    true,
 		})
 		is.NoErr(err)
+
 		_, err = pool.Exec(ctx, fmt.Sprintf(
 			`INSERT INTO %s (id, column1, column2, column3, column4, column5)
 				VALUES (7, 'buzz', 10101, true, 121.9, 51)`,

--- a/source/logrepl/internal/publication_test.go
+++ b/source/logrepl/internal/publication_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestCreatePublication(t *testing.T) {
 	ctx := context.Background()
-	conn := test.ConnectSimple(ctx, t, test.RepmgrConnString)
+	pool := test.ConnectPool(ctx, t, test.RegularConnString)
 
 	pubNames := []string{"testpub", "123", "test-hyphen", "test=equal"}
 	pubParams := [][]string{
@@ -36,8 +36,8 @@ func TestCreatePublication(t *testing.T) {
 	}
 
 	tables := []string{
-		test.SetupTestTable(ctx, t, conn),
-		test.SetupTestTable(ctx, t, conn),
+		test.SetupTestTable(ctx, t, pool),
+		test.SetupTestTable(ctx, t, pool),
 	}
 
 	for _, givenPubName := range pubNames {
@@ -47,7 +47,7 @@ func TestCreatePublication(t *testing.T) {
 				is := is.New(t)
 				err := CreatePublication(
 					ctx,
-					conn.PgConn(),
+					pool,
 					givenPubName,
 					CreatePublicationOptions{
 						Tables:            tables,
@@ -56,7 +56,7 @@ func TestCreatePublication(t *testing.T) {
 				)
 				is.NoErr(err)
 				// cleanup
-				is.NoErr(DropPublication(ctx, conn.PgConn(), givenPubName, DropPublicationOptions{}))
+				is.NoErr(DropPublication(ctx, pool, givenPubName, DropPublicationOptions{}))
 			})
 		}
 	}
@@ -73,11 +73,11 @@ func TestCreatePublication(t *testing.T) {
 func TestCreatePublicationForTables(t *testing.T) {
 	ctx := context.Background()
 	pub := test.RandomIdentifier(t)
-	conn := test.ConnectSimple(ctx, t, test.RegularConnString)
+	pool := test.ConnectPool(ctx, t, test.RegularConnString)
 
 	tables := [][]string{
-		{test.SetupTestTable(ctx, t, conn)},
-		{test.SetupTestTable(ctx, t, conn), test.SetupTestTable(ctx, t, conn)},
+		{test.SetupTestTable(ctx, t, pool)},
+		{test.SetupTestTable(ctx, t, pool), test.SetupTestTable(ctx, t, pool)},
 	}
 
 	for _, givenTables := range tables {
@@ -86,7 +86,7 @@ func TestCreatePublicationForTables(t *testing.T) {
 			is := is.New(t)
 			err := CreatePublication(
 				ctx,
-				conn.PgConn(),
+				pool,
 				pub,
 				CreatePublicationOptions{
 					Tables: givenTables,
@@ -94,7 +94,7 @@ func TestCreatePublicationForTables(t *testing.T) {
 			)
 			is.NoErr(err)
 			// cleanup
-			is.NoErr(DropPublication(ctx, conn.PgConn(), pub, DropPublicationOptions{}))
+			is.NoErr(DropPublication(ctx, pool, pub, DropPublicationOptions{}))
 		})
 	}
 }
@@ -104,10 +104,10 @@ func TestDropPublication(t *testing.T) {
 	is := is.New(t)
 	pub := test.RandomIdentifier(t)
 
-	conn := test.ConnectSimple(ctx, t, test.RegularConnString)
+	pool := test.ConnectPool(ctx, t, test.RegularConnString)
 	err := DropPublication(
 		ctx,
-		conn.PgConn(),
+		pool,
 		pub,
 		DropPublicationOptions{
 			IfExists: false, // fail if pub doesn't exist
@@ -118,7 +118,7 @@ func TestDropPublication(t *testing.T) {
 	// next connect with repmgr
 	err = DropPublication(
 		ctx,
-		conn.PgConn(),
+		pool,
 		pub,
 		DropPublicationOptions{
 			IfExists: true, // fail if pub doesn't exist

--- a/source/logrepl/internal/relationset_test.go
+++ b/source/logrepl/internal/relationset_test.go
@@ -49,12 +49,11 @@ func TestRelationSetAllTypes(t *testing.T) {
 	ctx := context.Background()
 	is := is.New(t)
 
-	conn := test.ConnectSimple(ctx, t, test.RepmgrConnString)
-	replConn := test.ConnectReplication(ctx, t, test.RepmgrConnString)
+	pool := test.ConnectPool(ctx, t, test.RepmgrConnString)
 
-	table := setupTableAllTypes(ctx, t, conn)
-	_, messages := setupSubscription(ctx, t, replConn, table)
-	insertRowAllTypes(ctx, t, conn, table)
+	table := setupTableAllTypes(ctx, t, pool)
+	_, messages := setupSubscription(ctx, t, pool, table)
+	insertRowAllTypes(ctx, t, pool, table)
 
 	var rel *pglogrepl.RelationMessage
 	var ins *pglogrepl.InsertMessage

--- a/source/logrepl/internal/replication_slot.go
+++ b/source/logrepl/internal/replication_slot.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/logrepl/internal/replication_slot.go
+++ b/source/logrepl/internal/replication_slot.go
@@ -1,0 +1,48 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var ErrMissingSlot = errors.New("replication slot missing")
+
+type ReplicationSlotResult struct {
+	Name              string
+	ConfirmedFlushLSN pglogrepl.LSN
+	RestartLSN        pglogrepl.LSN
+}
+
+// ReadReplicationSlot returns state of an existing replication slot.
+func ReadReplicationSlot(ctx context.Context, conn *pgxpool.Pool, name string) (ReplicationSlotResult, error) {
+	var r ReplicationSlotResult
+
+	qr := conn.QueryRow(ctx, "SELECT slot_name, confirmed_flush_lsn, restart_lsn FROM pg_replication_slots WHERE slot_name=$1", name)
+	if err := qr.Scan(&r.Name, &r.ConfirmedFlushLSN, &r.RestartLSN); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ReplicationSlotResult{}, fmt.Errorf("%s: %w", name, ErrMissingSlot)
+		}
+		return ReplicationSlotResult{}, fmt.Errorf("failed to read replication slot %q: %w", name, err)
+	}
+
+	return r, nil
+}

--- a/source/logrepl/internal/replication_slot.go
+++ b/source/logrepl/internal/replication_slot.go
@@ -26,22 +26,22 @@ import (
 
 var ErrMissingSlot = errors.New("replication slot missing")
 
-type ReplicationSlotResult struct {
+type ReadReplicationSlotResult struct {
 	Name              string
 	ConfirmedFlushLSN pglogrepl.LSN
 	RestartLSN        pglogrepl.LSN
 }
 
 // ReadReplicationSlot returns state of an existing replication slot.
-func ReadReplicationSlot(ctx context.Context, conn *pgxpool.Pool, name string) (ReplicationSlotResult, error) {
-	var r ReplicationSlotResult
+func ReadReplicationSlot(ctx context.Context, conn *pgxpool.Pool, name string) (ReadReplicationSlotResult, error) {
+	var r ReadReplicationSlotResult
 
 	qr := conn.QueryRow(ctx, "SELECT slot_name, confirmed_flush_lsn, restart_lsn FROM pg_replication_slots WHERE slot_name=$1", name)
 	if err := qr.Scan(&r.Name, &r.ConfirmedFlushLSN, &r.RestartLSN); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return ReplicationSlotResult{}, fmt.Errorf("%s: %w", name, ErrMissingSlot)
+			return ReadReplicationSlotResult{}, fmt.Errorf("%s: %w", name, ErrMissingSlot)
 		}
-		return ReplicationSlotResult{}, fmt.Errorf("failed to read replication slot %q: %w", name, err)
+		return ReadReplicationSlotResult{}, fmt.Errorf("failed to read replication slot %q: %w", name, err)
 	}
 
 	return r, nil

--- a/source/logrepl/internal/replication_slot_test.go
+++ b/source/logrepl/internal/replication_slot_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/logrepl/internal/replication_slot_test.go
+++ b/source/logrepl/internal/replication_slot_test.go
@@ -1,0 +1,62 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/conduitio/conduit-connector-postgres/test"
+	"github.com/matryer/is"
+)
+
+func Test_ReadReplicationSlot(t *testing.T) {
+	var (
+		ctx      = context.Background()
+		pool     = test.ConnectPool(ctx, t, test.RepmgrConnString)
+		slotName = test.RandomIdentifier(t)
+	)
+
+	t.Run("read replication slot", func(t *testing.T) {
+		is := is.New(t)
+
+		test.CreateReplicationSlot(t, pool, slotName)
+		res, err := ReadReplicationSlot(ctx, pool, slotName)
+		is.NoErr(err)
+		is.Equal(res.Name, slotName)
+		is.True(res.ConfirmedFlushLSN > 0)
+		is.True(res.RestartLSN > 0)
+	})
+
+	t.Run("fails when slot is missing", func(t *testing.T) {
+		is := is.New(t)
+
+		_, err := ReadReplicationSlot(ctx, pool, slotName)
+		is.True(err != nil)
+		is.True(errors.Is(err, ErrMissingSlot))
+	})
+
+	t.Run("fails when conn errors", func(t *testing.T) {
+		is := is.New(t)
+		pool := test.ConnectPool(ctx, t, test.RepmgrConnString)
+		pool.Close()
+
+		_, err := ReadReplicationSlot(ctx, pool, slotName)
+		is.True(err != nil)
+		is.Equal(err.Error(), fmt.Sprintf("failed to read replication slot %q: closed pool", slotName))
+	})
+}

--- a/source/logrepl/internal/subscription.go
+++ b/source/logrepl/internal/subscription.go
@@ -21,7 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	cpool "github.com/conduitio/conduit-connector-postgres/source/pool"
+	"github.com/conduitio/conduit-connector-postgres/source/cpool"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5/pgproto3"
@@ -68,8 +68,10 @@ func CreateSubscription(
 	startLSN pglogrepl.LSN,
 	h Handler,
 ) (*Subscription, error) {
+	var err error
+
 	// Request a replication connection
-	conn, err := pool.Acquire(context.WithValue(ctx, cpool.WithReplCtxKey, true))
+	conn, err := pool.Acquire(cpool.WithReplication(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("could not establish replication connection: %w", err)
 	}

--- a/source/logrepl/internal/subscription_test.go
+++ b/source/logrepl/internal/subscription_test.go
@@ -24,30 +24,29 @@ import (
 
 	"github.com/conduitio/conduit-connector-postgres/test"
 	"github.com/jackc/pglogrepl"
-	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/matryer/is"
 )
 
 func TestSubscription_Create(t *testing.T) {
 	ctx := context.Background()
 	is := is.New(t)
-	conn := test.ConnectReplication(ctx, t, test.RepmgrConnString)
-	conn.Close(ctx)
+	pool := test.ConnectPool(ctx, t, test.RepmgrConnString)
+	pool.Close()
 
-	_, err := CreateSubscription(ctx, conn, "slotname", "pubname", nil, 0, nil)
-	is.Equal(err.Error(), "conn closed")
+	_, err := CreateSubscription(ctx, pool, "slotname", "pubname", nil, 0, nil)
+	is.Equal(err.Error(), "could not establish replication connection: closed pool")
 }
 
 func TestSubscription_WithRepmgr(t *testing.T) {
-	ctx := context.Background()
+	var (
+		ctx    = context.Background()
+		pool   = test.ConnectPool(ctx, t, test.RepmgrConnString)
+		table1 = test.SetupTestTable(ctx, t, pool)
+		table2 = test.SetupTestTable(ctx, t, pool)
+	)
 
-	conn := test.ConnectSimple(ctx, t, test.RepmgrConnString)
-	replConn := test.ConnectReplication(ctx, t, test.RepmgrConnString)
-
-	table1 := test.SetupTestTable(ctx, t, conn)
-	table2 := test.SetupTestTable(ctx, t, conn)
-
-	sub, messages := setupSubscription(ctx, t, replConn, table1, table2)
+	sub, messages := setupSubscription(ctx, t, pool, table1, table2)
 
 	fetchAndAssertMessageTypes := func(is *is.I, m chan pglogrepl.Message, msgTypes ...pglogrepl.MessageType) []pglogrepl.Message {
 		out := make([]pglogrepl.Message, len(msgTypes))
@@ -67,7 +66,7 @@ func TestSubscription_WithRepmgr(t *testing.T) {
 		is := is.New(t)
 		query := `INSERT INTO %s (id, column1, column2, column3)
 		VALUES (6, 'bizz', 456, false)`
-		_, err := conn.Exec(ctx, fmt.Sprintf(query, table1))
+		_, err := pool.Exec(ctx, fmt.Sprintf(query, table1))
 		is.NoErr(err)
 
 		_ = fetchAndAssertMessageTypes(
@@ -85,7 +84,7 @@ func TestSubscription_WithRepmgr(t *testing.T) {
 		is := is.New(t)
 		query := `INSERT INTO %s (id, column1, column2, column3)
 		VALUES (7, 'bizz', 456, false)`
-		_, err := conn.Exec(ctx, fmt.Sprintf(query, table1))
+		_, err := pool.Exec(ctx, fmt.Sprintf(query, table1))
 		is.NoErr(err)
 
 		_ = fetchAndAssertMessageTypes(
@@ -101,7 +100,7 @@ func TestSubscription_WithRepmgr(t *testing.T) {
 	t.Run("first update table2", func(t *testing.T) {
 		is := is.New(t)
 		query := `UPDATE %s SET column1 = 'foo' WHERE id = 1`
-		_, err := conn.Exec(ctx, fmt.Sprintf(query, table2))
+		_, err := pool.Exec(ctx, fmt.Sprintf(query, table2))
 		is.NoErr(err)
 
 		_ = fetchAndAssertMessageTypes(
@@ -118,7 +117,7 @@ func TestSubscription_WithRepmgr(t *testing.T) {
 	t.Run("update all table 2", func(t *testing.T) {
 		is := is.New(t)
 		query := `UPDATE %s SET column1 = 'bar'` // update all rows
-		_, err := conn.Exec(ctx, fmt.Sprintf(query, table2))
+		_, err := pool.Exec(ctx, fmt.Sprintf(query, table2))
 		is.NoErr(err)
 
 		_ = fetchAndAssertMessageTypes(
@@ -152,18 +151,19 @@ func TestSubscription_WithRepmgr(t *testing.T) {
 
 func TestSubscription_ClosedContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	is := is.New(t)
 
-	conn := test.ConnectSimple(ctx, t, test.RepmgrConnString)
-	replConn := test.ConnectReplication(ctx, t, test.RepmgrConnString)
-	table := test.SetupTestTable(ctx, t, conn)
+	var (
+		is    = is.New(t)
+		pool  = test.ConnectPool(ctx, t, test.RepmgrConnString)
+		table = test.SetupTestTable(ctx, t, pool)
+	)
 
-	sub, messages := setupSubscription(ctx, t, replConn, table)
+	sub, messages := setupSubscription(ctx, t, pool, table)
 
 	// insert to get new messages into publication
 	query := `INSERT INTO %s (id, column1, column2, column3)
 		VALUES (6, 'bizz', 456, false)`
-	_, err := conn.Exec(ctx, fmt.Sprintf(query, table))
+	_, err := pool.Exec(ctx, fmt.Sprintf(query, table))
 	is.NoErr(err)
 
 	cancel()
@@ -213,7 +213,7 @@ func TestSubscription_Stop(t *testing.T) {
 func setupSubscription(
 	ctx context.Context,
 	t *testing.T,
-	replConn *pgconn.PgConn,
+	pool *pgxpool.Pool,
 	tables ...string,
 ) (*Subscription, chan pglogrepl.Message) {
 	is := is.New(t)
@@ -221,14 +221,12 @@ func setupSubscription(
 	slotName := test.RandomIdentifier(t)
 	publication := test.RandomIdentifier(t)
 
-	conn := test.ConnectSimple(ctx, t, test.RepmgrConnString)
-
-	test.CreatePublication(t, conn, publication, tables)
+	test.CreatePublication(t, pool, publication, tables)
 
 	messages := make(chan pglogrepl.Message)
 	sub, err := CreateSubscription(
 		ctx,
-		replConn,
+		pool,
 		slotName,
 		publication,
 		tables,
@@ -264,12 +262,11 @@ func setupSubscription(
 
 	t.Cleanup(func() {
 		// stop subscription
-		sub.Stop()
-		cctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		is.NoErr(sub.Wait(cctx, 0))
+		cctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		is.NoErr(sub.Teardown(cctx))
 		cancel()
 
-		_, err := conn.Exec(
+		_, err := pool.Exec(
 			context.Background(),
 			"SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name=$1",
 			slotName,

--- a/source/pool/pool.go
+++ b/source/pool/pool.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-var WithReplCtxKey = struct{}{}
+type replicationCtxKey struct{}
+
+func WithReplication(ctx context.Context) context.Context {
+	return context.WithValue(ctx, replicationCtxKey{}, true)
+}
 
 // New returns new pgxpool.Pool with added hooks.
 func New(ctx context.Context, conninfo string) (*pgxpool.Pool, error) {

--- a/source/pool/pool.go
+++ b/source/pool/pool.go
@@ -1,0 +1,68 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pool
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var WithReplCtxKey = struct{}{}
+
+// New returns new pgxpool.Pool with added hooks.
+func New(ctx context.Context, conninfo string) (*pgxpool.Pool, error) {
+	config, err := pgxpool.ParseConfig(conninfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pool config: %w", err)
+	}
+
+	config.BeforeAcquire = beforeAcquireHook
+	config.BeforeConnect = beforeConnectHook
+	config.AfterRelease = afterReleaseHook
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return pool, nil
+}
+
+// beforeAcquireHook ensures purpose specific connections are returned:
+// * If a replication connection is requested, ensure the connection has replication enabled.
+// * If a regular connection is requested, return non-replication connections.
+func beforeAcquireHook(ctx context.Context, conn *pgx.Conn) bool {
+	replReq := ctx.Value(WithReplCtxKey) != nil
+	replOn := conn.Config().RuntimeParams["replication"] != ""
+
+	return replReq == replOn
+}
+
+// beforeConnectHook customizes the configuration of the new connection.
+func beforeConnectHook(ctx context.Context, config *pgx.ConnConfig) error {
+	if v := ctx.Value(WithReplCtxKey); v != nil {
+		config.RuntimeParams["replication"] = "database"
+	}
+
+	return nil
+}
+
+// afterReleaseHook marks all replication connections for disposal.
+func afterReleaseHook(conn *pgx.Conn) bool {
+	return conn.Config().RuntimeParams["replication"] == ""
+}

--- a/test/conf.d/postgresql.conf
+++ b/test/conf.d/postgresql.conf
@@ -2,3 +2,7 @@ wal_level=logical
 max_wal_senders=5
 max_replication_slots=5
 log_statement='all'
+log_connections=true
+log_disconnections=true
+log_duration=true
+log_replication_commands=true

--- a/test/helper.go
+++ b/test/helper.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/conduitio/conduit-commons/csync"
-	cpool "github.com/conduitio/conduit-connector-postgres/source/pool"
+	"github.com/conduitio/conduit-connector-postgres/source/cpool"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"


### PR DESCRIPTION
### Description

* Read the state of the replication slot when subscription is created.
* Ensure the starting position in CDC mode is consistent with what is available in the slot.
* Refactor connection management to use pgxpool and allow for acquired connections to be upgraded for replication
* Add subscription teardown method which stops and waits for wind down.


Fixes #146 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
