### PR TITLE
don't check relAvroSchema on deletes

### DIFF
--- a/source/logrepl/handler.go
+++ b/source/logrepl/handler.go
@@ -179,7 +179,7 @@ func (h *CDCHandler) handleDelete(
 
 	rec := sdk.Util.Source.NewRecordDelete(
 		h.buildPosition(lsn),
-		h.buildRecordMetadata(rel),
+		h.buildRecordMetadata(rel, sdk.OperationDelete),
 		h.buildRecordKey(oldValues, rel.RelationName),
 	)
 	return h.send(ctx, rec)

--- a/source/logrepl/handler.go
+++ b/source/logrepl/handler.go
@@ -114,7 +114,7 @@ func (h *CDCHandler) handleInsert(
 
 	rec := sdk.Util.Source.NewRecordCreate(
 		h.buildPosition(lsn),
-		h.buildRecordMetadata(rel),
+		h.buildRecordMetadata(rel, sdk.OperationCreate),
 		h.buildRecordKey(newValues, rel.RelationName),
 		h.buildRecordPayload(newValues),
 	)
@@ -152,7 +152,7 @@ func (h *CDCHandler) handleUpdate(
 
 	rec := sdk.Util.Source.NewRecordUpdate(
 		h.buildPosition(lsn),
-		h.buildRecordMetadata(rel),
+		h.buildRecordMetadata(rel, sdk.OperationUpdate),
 		h.buildRecordKey(newValues, rel.RelationName),
 		h.buildRecordPayload(oldValues),
 		h.buildRecordPayload(newValues),
@@ -196,12 +196,12 @@ func (h *CDCHandler) send(ctx context.Context, rec sdk.Record) error {
 	}
 }
 
-func (h *CDCHandler) buildRecordMetadata(rel *pglogrepl.RelationMessage) map[string]string {
+func (h *CDCHandler) buildRecordMetadata(rel *pglogrepl.RelationMessage, op sdk.Operation) map[string]string {
 	m := map[string]string{
 		sdk.MetadataCollection: rel.RelationName,
 	}
 
-	if h.withAvroSchema {
+	if h.withAvroSchema && op != sdk.OperationDelete {
 		m[schema.AvroMetadataKey] = h.relAvroSchema[rel.RelationName].String()
 	}
 


### PR DESCRIPTION
### Description

This fixes a nil pointer reference for deletes. Note that [we invoke `updateAvroSchema()` on inserts and updates](https://github.com/ConduitIO/conduit-connector-postgres/blob/5ecd48eadec2f4881a41909942e48fa3149f350d/source/logrepl/handler.go#L142), but not deletes. Therefore, we should not check `relAvroSchema` on delete records.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
