### PR TITLE
Fix replication timeout right after long snapshot; avro fixes.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,12 +16,18 @@ linters-settings:
     values:
       regexp:
         copyright-year: 20[2-9]\d
-
+  forbidigo:
+    forbid:
+      - p: ^pgxpool\.New.*$
+        msg: "Use github.com/conduitio/conduit-connector-postgres/source/cpool.New instead."
 issues:
   exclude-rules:
     - path: test/helper\.go
       linters:
         - gosec
+    - path: source/cpool/cpool\.go
+      linters:
+      - forbidigo
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
@@ -38,7 +44,7 @@ linters:
     # - exhaustive
     # - exhaustivestruct
     - exportloopref
-    # - forbidigo
+    - forbidigo
     # - forcetypeassert
     # - funlen
     # - gochecknoinits

--- a/source/cpool/cpool.go
+++ b/source/cpool/cpool.go
@@ -59,6 +59,10 @@ func beforeAcquireHook(ctx context.Context, conn *pgx.Conn) bool {
 
 // beforeConnectHook customizes the configuration of the new connection.
 func beforeConnectHook(ctx context.Context, config *pgx.ConnConfig) error {
+	if config.RuntimeParams["application_name"] == "" {
+		config.RuntimeParams["application_name"] = "conduit-connector-postgres"
+	}
+
 	if v := ctx.Value(replicationCtxKey{}); v != nil {
 		config.RuntimeParams["replication"] = "database"
 	}

--- a/source/logrepl/cleaner.go
+++ b/source/logrepl/cleaner.go
@@ -19,9 +19,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/conduitio/conduit-connector-postgres/source/cpool"
 	"github.com/conduitio/conduit-connector-postgres/source/logrepl/internal"
 	sdk "github.com/conduitio/conduit-connector-sdk"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type CleanupConfig struct {
@@ -35,7 +35,7 @@ type CleanupConfig struct {
 func Cleanup(ctx context.Context, c CleanupConfig) error {
 	logger := sdk.Logger(ctx)
 
-	pool, err := pgxpool.New(ctx, c.URL)
+	pool, err := cpool.New(ctx, c.URL)
 	if err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/source/logrepl/combined_test.go
+++ b/source/logrepl/combined_test.go
@@ -165,6 +165,16 @@ func TestCombinedIterator_Next(t *testing.T) {
 
 	expectedRecords := testRecords()
 
+	// interrupt repl connection
+	var terminated bool
+	is.NoErr(pool.QueryRow(ctx, fmt.Sprintf(
+		`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE
+			query ILIKE '%%CREATE_REPLICATION_SLOT %s%%' and pid <> pg_backend_pid()
+		`,
+		table,
+	)).Scan(&terminated))
+	is.True(terminated)
+
 	// compare snapshot
 	for id := 1; id < 5; id++ {
 		t.Run(fmt.Sprint("next_snapshot", id), func(t *testing.T) {

--- a/source/schema/avro.go
+++ b/source/schema/avro.go
@@ -27,14 +27,7 @@ import (
 
 const (
 	avroNS = "conduit.postgres"
-	// The default decimal precision is pretty generous, but it is in excess of what
-	// pgx provides by default. All numeric values by default are coded to float64/int64.
-	// Ideally in the future the decimal precision can be adjusted to fit the definition in postgres.
-	avroDecimalPrecision = 38
-	// The size of the storage in which a decimal may be encoded depends on the underlying numeric definition.
-	// Unfortunately similarly to the decimal precision, this is dependent on the size of the numeric, which
-	// by default is constraint to 8 bytes. This default is generously allocating four times larger width.
-	avroDecimalFixedSize = 8 * 4
+	avroDecimalPadding = 8
 )
 
 var Avro = &avroExtractor{
@@ -133,7 +126,7 @@ func (a *avroExtractor) extractType(t *pgtype.Type, typeMod int32) (avro.Schema,
 		fs, err := avro.NewFixedSchema(
 			string(avro.Decimal),
 			avroNS,
-			avroDecimalFixedSize,
+			precision + scale + avroDecimalPadding,
 			avro.NewDecimalLogicalSchema(precision, scale),
 		)
 		if err != nil {

--- a/source/schema/avro.go
+++ b/source/schema/avro.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	avroNS = "conduit.postgres"
+	avroNS             = "conduit.postgres"
 	avroDecimalPadding = 8
 )
 
@@ -126,7 +126,7 @@ func (a *avroExtractor) extractType(t *pgtype.Type, typeMod int32) (avro.Schema,
 		fs, err := avro.NewFixedSchema(
 			string(avro.Decimal),
 			avroNS,
-			precision + scale + avroDecimalPadding,
+			precision+scale+avroDecimalPadding,
 			avro.NewDecimalLogicalSchema(precision, scale),
 		)
 		if err != nil {
@@ -137,4 +137,3 @@ func (a *avroExtractor) extractType(t *pgtype.Type, typeMod int32) (avro.Schema,
 		return nil, fmt.Errorf("cannot resolve field type %q ", t.Name)
 	}
 }
-

--- a/source/schema/avro_test.go
+++ b/source/schema/avro_test.go
@@ -50,7 +50,7 @@ func Test_AvroExtract(t *testing.T) {
 
 	fields := rows.FieldDescriptions()
 
-	sch, err := Avro.Extract(table, fields, values)
+	sch, err := Avro.Extract(table, fields)
 
 	t.Run("schema is parsable", func(t *testing.T) {
 		is := is.New(t)
@@ -192,7 +192,7 @@ func avroTestSchema(t *testing.T, table string) avro.Schema {
 			assert(avro.NewFixedSchema(string(avro.Decimal),
 				avroNS,
 				avroDecimalFixedSize,
-				avro.NewDecimalLogicalSchema(avroDecimalPrecision, 2),
+				avro.NewDecimalLogicalSchema(8, 2),
 			)))),
 		assert(avro.NewField("col_date", avro.NewPrimitiveSchema(
 			avro.Int,

--- a/source/schema/avro_test.go
+++ b/source/schema/avro_test.go
@@ -191,7 +191,7 @@ func avroTestSchema(t *testing.T, table string) avro.Schema {
 		assert(avro.NewField("col_numeric",
 			assert(avro.NewFixedSchema(string(avro.Decimal),
 				avroNS,
-				avroDecimalFixedSize,
+				18,
 				avro.NewDecimalLogicalSchema(8, 2),
 			)))),
 		assert(avro.NewField("col_date", avro.NewPrimitiveSchema(

--- a/source/snapshot/fetch_worker.go
+++ b/source/snapshot/fetch_worker.go
@@ -286,7 +286,7 @@ func (f *FetchWorker) fetch(ctx context.Context, tx pgx.Tx) (int, error) {
 		}
 
 		if f.conf.WithAvroSchema && f.avroSchema == nil {
-			sch, err := schema.Avro.Extract(f.conf.Table, fields, values)
+			sch, err := schema.Avro.Extract(f.conf.Table, fields)
 			if err != nil {
 				return 0, fmt.Errorf("failed to extract schema: %w", err)
 			}


### PR DESCRIPTION
### Description

* Fix issues related to repl connection disconnect right after long snapshot completes.
* Fix block when replication cannot start, for any reason.
* Avro decimal fixes

Fixes #181 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
