### PR TITLE
Fix race in combined iterator test

### DIFF
--- a/source/logrepl/combined_test.go
+++ b/source/logrepl/combined_test.go
@@ -165,16 +165,6 @@ func TestCombinedIterator_Next(t *testing.T) {
 
 	expectedRecords := testRecords()
 
-	// interrupt repl connection
-	var terminated bool
-	is.NoErr(pool.QueryRow(ctx, fmt.Sprintf(
-		`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE
-			query ILIKE '%%CREATE_REPLICATION_SLOT %s%%' and pid <> pg_backend_pid()
-		`,
-		table,
-	)).Scan(&terminated))
-	is.True(terminated)
-
 	// compare snapshot
 	for id := 1; id < 5; id++ {
 		t.Run(fmt.Sprint("next_snapshot", id), func(t *testing.T) {
@@ -193,6 +183,16 @@ func TestCombinedIterator_Next(t *testing.T) {
 			is.NoErr(i.Ack(ctx, r.Position))
 		})
 	}
+
+	// interrupt repl connection
+	var terminated bool
+	is.NoErr(pool.QueryRow(ctx, fmt.Sprintf(
+		`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE
+			query ILIKE '%%CREATE_REPLICATION_SLOT %s%%' and pid <> pg_backend_pid()
+		`,
+		table,
+	)).Scan(&terminated))
+	is.True(terminated)
 
 	t.Run("next_cdc_5", func(t *testing.T) {
 		is := is.New(t)


### PR DESCRIPTION
### Description

The fetchers may not have started right after the iterator is created. Interrupt after snapshotter has started.

Fixes ![Screenshot 2024-07-18 at 17 54 43](https://github.com/user-attachments/assets/a0bf398e-3afa-49c0-b6bc-1b0e530420f4)

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
