### PR TITLE
Postgres source will produce its own schema; disable autogen

### DIFF
--- a/source.go
+++ b/source.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/csync"
+	"github.com/conduitio/conduit-commons/lang"
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit-connector-postgres/source"
 	"github.com/conduitio/conduit-connector-postgres/source/cpool"
@@ -46,7 +47,13 @@ func NewSource() sdk.Source {
 		&Source{
 			tableKeys: make(map[string]string),
 		},
-		sdk.DefaultSourceMiddleware()...,
+		sdk.DefaultSourceMiddleware(
+			// disable schema extraction by default, postgres will build its own schema
+			sdk.SourceWithSchemaExtractionConfig{
+				PayloadEnabled: lang.Ptr(false),
+				KeyEnabled:     lang.Ptr(false),
+			},
+		)...,
 	)
 }
 


### PR DESCRIPTION
### Description

Postgres source will produce its own schema; disable autogen.

In preparation to enable schema building in Postgres

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
