### PR TITLE
fix: md format & destination table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Conduit Connector PostgreSQL
+
 ![scarf pixel](https://static.scarf.sh/a.png?x-pxid=1423de19-24e7-4d64-91cf-0b893ca28cc6)
 
 The PostgreSQL connector is a [Conduit](https://github.com/ConduitIO/conduit) plugin. It provides both, a source
@@ -57,16 +58,16 @@ the connector will return an error.
 
 ## Configuration Options
 
-| name                      | description                                                                                                                                   | required | default       |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
-| `url`                     | Connection string for the Postgres database.                                                                                                  | true     |               |
-| `tables`                  | List of table names to read from, separated by comma. Example: `"employees,offices,payments"`. Using `*` will read from all public tables.    | true     |               |
-| `snapshotMode`            | Whether or not the plugin will take a snapshot of the entire table before starting cdc mode (allowed values: `initial` or `never`).           | false    | `initial`     |
-| `cdcMode`                 | Determines the CDC mode (allowed values: `auto`, `logrepl`).                                                                                  | false    | `auto`        |
-| `logrepl.publicationName` | Name of the publication to listen for WAL events.                                                                                             | false    | `conduitpub`  |
-| `logrepl.slotName`        | Name of the slot opened for replication events.                                                                                               | false    | `conduitslot` |
-| `logrepl.autoCleanup`     | Whether or not to cleanup the replication slot and pub when connector is deleted                                                              | false    | `true` |
-| ~~`table`~~               | List of table names to read from, separated by comma. **Deprecated: use `tables` instead.**                                                   | false    |               |
+| name                      | description                                                                                                                                | required | default       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------------- |
+| `url`                     | Connection string for the Postgres database.                                                                                               | true     |               |
+| `tables`                  | List of table names to read from, separated by comma. Example: `"employees,offices,payments"`. Using `*` will read from all public tables. | true     |               |
+| `snapshotMode`            | Whether or not the plugin will take a snapshot of the entire table before starting cdc mode (allowed values: `initial` or `never`).        | false    | `initial`     |
+| `cdcMode`                 | Determines the CDC mode (allowed values: `auto`, `logrepl`).                                                                               | false    | `auto`        |
+| `logrepl.publicationName` | Name of the publication to listen for WAL events.                                                                                          | false    | `conduitpub`  |
+| `logrepl.slotName`        | Name of the slot opened for replication events.                                                                                            | false    | `conduitslot` |
+| `logrepl.autoCleanup`     | Whether or not to cleanup the replication slot and pub when connector is deleted                                                           | false    | `true`        |
+| ~~`table`~~               | List of table names to read from, separated by comma. **Deprecated: use `tables` instead.**                                                | false    |               |
 
 # Destination
 
@@ -84,9 +85,10 @@ If there is no key, the record will be simply appended.
 ## Configuration Options
 
 | name    | description                                                                                                                                                                           | required | default                                      |
-|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------------------------------------------|
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------- |
 | `url`   | Connection string for the Postgres database.                                                                                                                                          | true     |                                              |
 | `table` | Table name. It can contain a Go template that will be executed for each record to determine the table. By default, the table is the value of the `opencdc.collection` metadata field. | false    | `{{ index .Metadata "opencdc.collection" }}` |
+| `key`   | Key represents the column name for the key used to identify and update existing rows.                                                                                                 | false    |                                              |
 
 # Testing
 


### PR DESCRIPTION
### Description

The destination option table is missing a key field.

Fixes # (issue)

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
