### PR TITLE
Use bytes instead of [n]bytes to represent decimal type

### DIFF
--- a/source/schema/avro_test.go
+++ b/source/schema/avro_test.go
@@ -188,12 +188,10 @@ func avroTestSchema(t *testing.T, table string) avro.Schema {
 		assert(avro.NewField("col_int4", avro.NewPrimitiveSchema(avro.Int, nil))),
 		assert(avro.NewField("col_int8", avro.NewPrimitiveSchema(avro.Long, nil))),
 		assert(avro.NewField("col_text", avro.NewPrimitiveSchema(avro.String, nil))),
-		assert(avro.NewField("col_numeric",
-			assert(avro.NewFixedSchema(fmt.Sprintf("%s_%d_%d", avro.Decimal, 8, 2),
-				"",
-				18,
-				avro.NewDecimalLogicalSchema(8, 2),
-			)))),
+		assert(avro.NewField("col_numeric", avro.NewPrimitiveSchema(
+			avro.Bytes,
+			avro.NewDecimalLogicalSchema(8, 2),
+		))),
 		assert(avro.NewField("col_date", avro.NewPrimitiveSchema(
 			avro.Int,
 			avro.NewPrimitiveLogicalSchema(avro.Date),

--- a/test/helper.go
+++ b/test/helper.go
@@ -51,9 +51,7 @@ const TestTableAvroSchemaV1 = `{
             "name": "column4",
             "type":
             {
-                "name": "decimal_16_3",
-                "type": "fixed",
-                "size": 27,
+                "type": "bytes",
                 "logicalType": "decimal",
                 "precision": 16,
                 "scale": 3
@@ -63,9 +61,7 @@ const TestTableAvroSchemaV1 = `{
             "name": "column5",
             "type":
             {
-                "name": "decimal_5_0",
-                "type": "fixed",
-                "size": 13,
+                "type": "bytes",
                 "logicalType": "decimal",
                 "precision": 5
             }
@@ -88,9 +84,7 @@ const TestTableAvroSchemaV2 = `{
             "name": "column4",
             "type":
             {
-                "name": "decimal_16_3",
-                "type": "fixed",
-                "size": 27,
+                "type": "bytes",
                 "logicalType": "decimal",
                 "precision": 16,
                 "scale": 3
@@ -100,9 +94,7 @@ const TestTableAvroSchemaV2 = `{
             "name": "column5",
             "type":
             {
-                "name": "decimal_5_0",
-                "type": "fixed",
-                "size": 13,
+                "type": "bytes",
                 "logicalType": "decimal",
                 "precision": 5
             }


### PR DESCRIPTION

### Description

Since each value may have larger size, as per spec https://avro.apache.org/docs/1.10.2/spec.pdf

```json
{
  "type": "bytes",
  "logicalType": "decimal",
  "precision": 4,
  "scale": 2
}
```

> A decimal logical type annotates Avro bytes or fixed types. The byte array must contain the two's-complement representation of the unscaled integer value in big-endian byte order. The scale is fixed, and is specified using an attribute.


### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
