### PR TITLE
add opencdc.collection metadata key for snapshots

### DIFF
--- a/source/snapshot/iterator.go
+++ b/source/snapshot/iterator.go
@@ -120,7 +120,7 @@ func (i *Iterator) buildRecord(d FetchData) opencdc.Record {
 
 	pos := i.lastPosition.ToSDKPosition()
 	metadata := make(opencdc.Metadata)
-	metadata["postgres.table"] = d.Table
+	metadata[opencdc.MetadataCollection] = d.Table
 
 	rec := sdk.Util.Source.NewRecordSnapshot(pos, metadata, d.Key, d.Payload)
 	if i.conf.WithAvroSchema {

--- a/source/snapshot/iterator_test.go
+++ b/source/snapshot/iterator_test.go
@@ -52,6 +52,7 @@ func Test_Iterator_Next(t *testing.T) {
 			r, err := i.Next(ctx)
 			is.NoErr(err)
 			is.Equal(r.Operation, opencdc.OperationSnapshot)
+			is.Equal(r.Metadata[opencdc.MetadataCollection], table)
 		}
 
 		for j := 1; j <= 4; j++ {


### PR DESCRIPTION
### Description

snapshot records don't have the metadata key opencdc.collection

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
