### PR TITLE
Property 'check-shadowing' is not allowed 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 linters-settings:
   gofmt:
     simplify: false
-  govet:
-    check-shadowing: false
   nolintlint:
     allow-unused: false # report any unused nolint directives
     require-explanation: true # require an explanation for nolint directives


### PR DESCRIPTION
### Description

this field is no longer supported, and is causing problems with the linter workflow for other PRs, like this [one](https://github.com/ConduitIO/conduit-connector-postgres/pull/251).
this PR removes the `check-shadowing` proberty.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
