### PR TITLE
fix: speed on ReadN

### DIFF
--- a/source/logrepl/cdc.go
+++ b/source/logrepl/cdc.go
@@ -125,7 +125,7 @@ func (i *CDCIterator) NextN(ctx context.Context, n int) ([]opencdc.Record, error
 	}
 
 	// 40K msg/s
-	//recs := make([]opencdc.Record, 0, n)
+	// recs := make([]opencdc.Record, 0, n)
 
 	// 150K msg/s
 	var recs []opencdc.Record

--- a/source/logrepl/cdc.go
+++ b/source/logrepl/cdc.go
@@ -124,7 +124,11 @@ func (i *CDCIterator) NextN(ctx context.Context, n int) ([]opencdc.Record, error
 		return nil, fmt.Errorf("n must be greater than 0, got %d", n)
 	}
 
-	recs := make([]opencdc.Record, 0, n)
+	// 40K msg/s
+	//recs := make([]opencdc.Record, 0, n)
+
+	// 150K msg/s
+	var recs []opencdc.Record
 
 	// Block until at least one record is received or context is canceled
 	select {

--- a/source/logrepl/cdc.go
+++ b/source/logrepl/cdc.go
@@ -124,10 +124,6 @@ func (i *CDCIterator) NextN(ctx context.Context, n int) ([]opencdc.Record, error
 		return nil, fmt.Errorf("n must be greater than 0, got %d", n)
 	}
 
-	// 40K msg/s
-	// recs := make([]opencdc.Record, 0, n)
-
-	// 150K msg/s
 	var recs []opencdc.Record
 
 	// Block until at least one record is received or context is canceled

--- a/source/logrepl/cdc_test.go
+++ b/source/logrepl/cdc_test.go
@@ -510,7 +510,7 @@ func TestCDCIterator_NextN(t *testing.T) {
 		}
 
 		// Will keep calling NextN until all records are received
-		var records []opencdc.Record
+		records := make([]opencdc.Record, 0, 2)
 		for len(records) < 2 {
 			recordsTmp, err := i.NextN(ctx, 5)
 			is.NoErr(err)

--- a/source/logrepl/combined.go
+++ b/source/logrepl/combined.go
@@ -131,7 +131,7 @@ func (c *CombinedIterator) NextN(ctx context.Context, n int) ([]opencdc.Record, 
 		}
 
 		sdk.Logger(ctx).Debug().Msg("Snapshot completed, switching to CDC mode")
-		return c.activeIterator.NextN(ctx, n)
+		return c.NextN(ctx, n)
 	}
 	return records, nil
 }

--- a/source/logrepl/combined_test.go
+++ b/source/logrepl/combined_test.go
@@ -289,7 +289,7 @@ func TestCombinedIterator_NextN(t *testing.T) {
 		is.NoErr(err)
 
 		// Request 2 records in CDC mode
-		var records []opencdc.Record
+		records := make([]opencdc.Record, 0, 2)
 		var retries int
 		maxRetries := 10
 		for retries < maxRetries {


### PR DESCRIPTION
### Description

Something on https://github.com/ConduitIO/conduit-connector-postgres/pull/276, more particularly on [this diff](https://github.com/conduitio/conduit-connector-postgres/compare/3331840fb4fd74416a49a487eead71c37f21eae8..d61629dab4fdabda593404d72bca7d1c7b0e1fc2), made my benchmarks slower. 

i.e.: 

- commit 3331840fb4fd74416a49a487eead71c37f21eae8 was fast 
- commit d61629dab4fdabda593404d72bca7d1c7b0e1fc2 was 10x slower.

**Update**

⚠️ This fixes the issue: https://github.com/ConduitIO/conduit-connector-postgres/pull/279/commits/4abb909c15218c9f0a99a3815954d41bdac7d6bd ⚠️

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
