### PR TITLE
Validate logical replication slot name

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ pipelines:
           logrepl.publicationName: "conduitpub"
           # LogreplSlotName determines the replication slot name in case the
           # connector uses logical replication to listen to changes (see
-          # CDCMode).
+          # CDCMode). Can only contain lower-case letters, numbers, and the
+          # underscore character.
           # Type: string
           # Required: no
           logrepl.slotName: "conduitslot"

--- a/connector.yaml
+++ b/connector.yaml
@@ -136,9 +136,12 @@ specification:
         description: |-
           LogreplSlotName determines the replication slot name in case the
           connector uses logical replication to listen to changes (see CDCMode).
+          Can only contain lower-case letters, numbers, and the underscore character.
         type: string
         default: conduitslot
-        validations: []
+        validations:
+          - type: regex
+            value: ^[a-z0-9_]+$
       - name: logrepl.withAvroSchema
         description: |-
           WithAvroSchema determines whether the connector should attach an avro schema on each

--- a/source/config.go
+++ b/source/config.go
@@ -69,7 +69,8 @@ type Config struct {
 	LogreplPublicationName string `json:"logrepl.publicationName" default:"conduitpub"`
 	// LogreplSlotName determines the replication slot name in case the
 	// connector uses logical replication to listen to changes (see CDCMode).
-	LogreplSlotName string `json:"logrepl.slotName" default:"conduitslot"`
+	// Can only contain lower-case letters, numbers, and the underscore character.
+	LogreplSlotName string `json:"logrepl.slotName" validate:"regex=^[a-z0-9_]+$" default:"conduitslot"`
 
 	// LogreplAutoCleanup determines if the replication slot and publication should be
 	// removed when the connector is deleted.

--- a/source/logrepl/internal/publication_test.go
+++ b/source/logrepl/internal/publication_test.go
@@ -27,7 +27,7 @@ func TestCreatePublication(t *testing.T) {
 	ctx := test.Context(t)
 	pool := test.ConnectPool(ctx, t, test.RegularConnString)
 
-	pubNames := []string{"testpub", "123", "test-hyphen", "test=equal"}
+	pubNames := []string{"testpub", "123", "test-hyphen", "test:semicolon", "test.dot", "test=equal"}
 	pubParams := [][]string{
 		nil,
 		{"publish = 'insert'"},


### PR DESCRIPTION
### Description

In the spirit of getting familiar with the code base I added a fix with validation rules for `logrepl.slotName` config which I myself got bitten by.

Turns out, publications are fine with special characters in the name, but not replication slots.
Oddly, this is the only place where it's documented: https://www.postgresql.org/docs/17/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
