### PR TITLE
fix snapshot allocation

### DIFF
--- a/connector.yaml
+++ b/connector.yaml
@@ -91,7 +91,7 @@ specification:
     deleted, the record will be ignored.
 
     If there is no key, the record will be simply appended.
-  version: v0.12.0
+  version: v0.12.1
   author: Meroxa, Inc.
   source:
     parameters:

--- a/source/snapshot/iterator.go
+++ b/source/snapshot/iterator.go
@@ -87,7 +87,7 @@ func (i *Iterator) NextN(ctx context.Context, n int) ([]opencdc.Record, error) {
 		return nil, fmt.Errorf("n must be greater than 0, got %d", n)
 	}
 
-	records := make([]opencdc.Record, 0, n)
+	var records []opencdc.Record
 
 	// Get first record (blocking)
 	select {


### PR DESCRIPTION
### Description

Leftover from https://github.com/ConduitIO/conduit-connector-postgres/pull/279. Forgot the snapshot iterator:

- with `records := make([]opencdc.Record, 0, n)` => 8332.25 msg/s 
- with `var records []opencdc.Record` => 148174.05 msg/s

It prepares the connector for a newer release.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
