### PR TITLE
feat(source): DBZ-3 Area 1 — resumable-snapshot low watermark + handoff re-seed

### DIFF
--- a/source/logrepl/cdc.go
+++ b/source/logrepl/cdc.go
@@ -49,8 +49,9 @@ type CDCConfig struct {
 // CDCIterator asynchronously listens for events from the logical replication
 // slot and returns them to the caller through NextN.
 type CDCIterator struct {
-	config CDCConfig
-	sub    *internal.Subscription
+	config  CDCConfig
+	sub     *internal.Subscription
+	handler *CDCHandler
 
 	// batchesCh is a channel shared between this iterator and a CDCHandler,
 	// to which the CDCHandler is sending batches of records.
@@ -118,6 +119,7 @@ func NewCDCIterator(ctx context.Context, pool *pgxpool.Pool, c CDCConfig) (*CDCI
 		config:    c,
 		batchesCh: batchesCh,
 		sub:       sub,
+		handler:   handler,
 	}, nil
 }
 
@@ -318,4 +320,37 @@ func (i *CDCIterator) subscriberReady() bool {
 // iterator is resuming.
 func (i *CDCIterator) TXSnapshotID() string {
 	return i.sub.TXSnapshotID
+}
+
+// LowWatermarkLSN returns the replication slot's restart_lsn captured when the
+// slot was read at subscription creation (DBZ-3 Area 1). It is only the snapshot
+// low watermark — the consistent point the initial snapshot is correlated with —
+// when this run freshly created the slot, i.e. when TXSnapshotID() is non-empty.
+// On a resume it reflects the slot's current restart_lsn and must not be used as
+// the watermark; the persisted position's SnapshotLowWatermarkLSN is authoritative
+// in that case. See CombinedIterator for the gating.
+func (i *CDCIterator) LowWatermarkLSN() pglogrepl.LSN {
+	return i.sub.RestartLSN
+}
+
+// SetSnapshotLowWatermarkLSN re-seeds the SnapshotLowWatermarkLSN that the
+// handler carries forward onto every CDC-mode position it builds (DBZ-3 Area 1,
+// acceptance criterion 11).
+//
+// It exists to fix the in-run snapshot->CDC handoff: NewCDCIterator seeds the
+// handler's base position once, at construction, from the position the connector
+// started with. On a first run that start position has no watermark (it is
+// captured only when the slot is created, which happens inside NewCDCIterator
+// itself), so without this call the watermark would ride snapshot records but be
+// silently dropped the instant CDC took over — criterion 11 would hold only for
+// the resumed case, not the first-run same-run handoff. CombinedIterator calls
+// this at the handoff (useCDCIterator) with the effective watermark.
+//
+// Concurrency: this MUST be called before StartSubscriber. The handler's base
+// position is only read on the single subscription goroutine (via Handle), which
+// does not run until StartSubscriber launches it, so re-seeding beforehand needs
+// no locking — the same single-writer-before-start discipline the base position
+// relied on at construction.
+func (i *CDCIterator) SetSnapshotLowWatermarkLSN(lsn string) {
+	i.handler.setBasePositionLowWatermark(lsn)
 }

--- a/source/logrepl/combined.go
+++ b/source/logrepl/combined.go
@@ -39,6 +39,15 @@ type CombinedIterator struct {
 	cdcIterator      *CDCIterator
 	snapshotIterator *snapshot.Iterator
 	activeIterator   iterator
+
+	// snapshotLowWatermarkLSN is the effective snapshot low watermark for this
+	// run (DBZ-3 Area 1): the persisted watermark on a resume, or the slot's
+	// consistent point captured at fresh slot creation on a first run. It is
+	// stored here so useCDCIterator can re-seed the CDC handler with it at the
+	// snapshot->CDC handoff, ensuring every CDC-mode position carries the
+	// watermark forward even on a first-run same-run handoff. Empty when this run
+	// does not snapshot (WithSnapshot=false or resuming directly in CDC mode).
+	snapshotLowWatermarkLSN string
 }
 
 type Config struct {
@@ -86,10 +95,25 @@ func NewCombinedIterator(ctx context.Context, pool *pgxpool.Pool, conf Config) (
 		pool: pool,
 	}
 
-	// Initialize the CDC iterator.
+	// Initialize the CDC iterator. This creates (or, on a resume, reuses) the
+	// replication slot, so the slot's consistent point is only known afterwards.
 	if err := c.initCDCIterator(ctx, pos); err != nil {
 		return nil, err
 	}
+
+	// DBZ-3 Area 1: determine the effective snapshot low watermark before starting
+	// the snapshot. On a fresh slot creation (TXSnapshotID present) the slot's
+	// restart_lsn is the consistent point the exported snapshot is correlated with,
+	// so it becomes the low watermark. On a resume the watermark is already carried
+	// in the persisted position and must NOT be overwritten (the slot's current
+	// restart_lsn may have advanced past the original snapshot point). Only capture
+	// it when this run will actually snapshot; a pure CDC start has no snapshot to
+	// reconcile against.
+	willSnapshot := c.conf.WithSnapshot && pos.Type != position.TypeCDC
+	if willSnapshot && pos.SnapshotLowWatermarkLSN == "" && c.cdcIterator.TXSnapshotID() != "" {
+		pos.SnapshotLowWatermarkLSN = c.cdcIterator.LowWatermarkLSN().String()
+	}
+	c.snapshotLowWatermarkLSN = pos.SnapshotLowWatermarkLSN
 
 	// Initialize the snapshot iterator when snapshotting is enabled and not completed.
 	// The CDC iterator must be initialized first when snapshotting is requested.
@@ -209,12 +233,20 @@ func (c *CombinedIterator) initSnapshotIterator(ctx context.Context, pos positio
 	}
 
 	snapshotIterator, err := snapshot.NewIterator(ctx, c.pool, snapshot.Config{
-		Position:       c.conf.Position,
+		// Pass the enriched position (carrying the captured/persisted low
+		// watermark) rather than c.conf.Position, so every snapshot record
+		// carries SnapshotLowWatermarkLSN forward (DBZ-3 Area 1).
+		Position:       pos.ToSDKPosition(),
 		Tables:         c.conf.Tables,
 		TableKeys:      c.conf.TableKeys,
 		TXSnapshotID:   c.cdcIterator.TXSnapshotID(),
 		FetchSize:      c.conf.BatchSize,
 		WithAvroSchema: c.conf.WithAvroSchema,
+		// A snapshot-typed start position means a prior run already persisted
+		// snapshot progress: this is a resume, so tag emitted records
+		// accordingly (DBZ-3 Area 1). A first run starts from an initial/empty
+		// position and is therefore not tagged.
+		SnapshotResumed: pos.Type == position.TypeSnapshot,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot iterator: %w", err)
@@ -237,6 +269,26 @@ func (c *CombinedIterator) useCDCIterator(ctx context.Context) error {
 	}
 
 	c.activeIterator, c.snapshotIterator = c.cdcIterator, nil
+
+	// DBZ-3 Area 1 (load-bearing): re-seed the CDC handler's low watermark at the
+	// snapshot->CDC handoff, BEFORE StartSubscriber launches the subscription
+	// goroutine. On a first run the watermark was captured only after the CDC
+	// iterator (and its handler) were constructed, so the handler's base position
+	// does not yet carry it; without this re-seed the watermark would ride
+	// snapshot records but be dropped the instant CDC took over — criterion 11
+	// would hold for the resumed case but silently regress on the first-run
+	// same-run handoff (the "intermittent regression" the design doc warns about).
+	// Re-seeding here is race-free: Handle (the only reader of the base position)
+	// does not run until StartSubscriber below.
+	//
+	// Invariant 1 (no early ack / WAL not pruned past unpersisted data): starting
+	// the subscriber here is the FIRST point CDC consumes or acks anything, so the
+	// slot's confirmed_flush_lsn cannot have advanced past the low watermark during
+	// the snapshot — it advances only via CDCIterator.Ack after the engine durably
+	// persists a record, all of which happens strictly after this handoff. This
+	// re-seed reads/writes only in-process position state and does not touch the
+	// ack or SendStandbyStatusUpdate path, so it cannot advance the slot early.
+	c.cdcIterator.SetSnapshotLowWatermarkLSN(c.snapshotLowWatermarkLSN)
 
 	if err := c.cdcIterator.StartSubscriber(ctx); err != nil {
 		return fmt.Errorf("failed to start CDC iterator: %w", err)

--- a/source/logrepl/combined_test.go
+++ b/source/logrepl/combined_test.go
@@ -24,8 +24,10 @@ import (
 
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit-connector-postgres/source/position"
+	"github.com/conduitio/conduit-connector-postgres/source/snapshot"
 	"github.com/conduitio/conduit-connector-postgres/test"
 	"github.com/google/go-cmp/cmp"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/matryer/is"
 )
 
@@ -435,4 +437,257 @@ func testRecords() []opencdc.StructuredData {
 			"UppercaseColumn1": nil,
 		},
 	}
+}
+
+// snapshotTableIDs returns the full set of primary-key ids currently in the
+// table, used by the resumable-snapshot chaos tests to assert no rows are
+// skipped ("no gap") across a crash+resume.
+func snapshotTableIDs(ctx context.Context, t *testing.T, pool *pgxpool.Pool, table string) map[int64]bool {
+	is := is.New(t)
+	rows, err := pool.Query(ctx, fmt.Sprintf("SELECT id FROM %q ORDER BY id", table))
+	is.NoErr(err)
+	defer rows.Close()
+
+	ids := make(map[int64]bool)
+	for rows.Next() {
+		var id int64
+		is.NoErr(rows.Scan(&id))
+		ids[id] = true
+	}
+	is.NoErr(rows.Err())
+	return ids
+}
+
+func recordID(t *testing.T, r opencdc.Record) int64 {
+	is := is.New(t)
+	data, ok := r.Payload.After.(opencdc.StructuredData)
+	is.True(ok)
+	id, ok := data["id"].(int64)
+	is.True(ok)
+	return id
+}
+
+// TestCombinedIterator_ResumeMidSnapshot_ResumedTag is DBZ-3 Area 1 acceptance
+// criterion 2 (crash-mid-snapshot chaos): a snapshot is interrupted partway, the
+// connector is torn down (simulating a crash), and a fresh connector resumes from
+// the persisted snapshot position. It asserts:
+//   - first-run records are NOT tagged resumed;
+//   - every record emitted by the resumed run carries
+//     postgres.snapshot.resumed=true AND carries the low watermark forward on its
+//     position;
+//   - the union of ids read across both runs covers the whole table (no gap).
+//
+// This is DB-gated (needs the test Postgres from test/docker-compose.yml). It is
+// WRITTEN-BUT-UNRUN wherever docker is unavailable; CI runs it via `make test`.
+func TestCombinedIterator_ResumeMidSnapshot_ResumedTag(t *testing.T) {
+	ctx := test.Context(t)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*120)
+	defer cancel()
+	is := is.New(t)
+
+	pool := test.ConnectPool(ctx, t, test.RepmgrConnString)
+	table := test.SetupTestTable(ctx, t, pool)
+
+	// Seed extra rows so a small-batch read leaves the snapshot genuinely
+	// incomplete at the simulated crash.
+	for n := 0; n < 20; n++ {
+		_, err := pool.Exec(ctx, fmt.Sprintf(
+			`INSERT INTO %q (key, column1, column2, column3, column4, column5, column6, column7, "UppercaseColumn1")
+				VALUES ('%d', 'r', 1, false, 1.1, 1, '{"a":1}', '{"a":1}', 1)`,
+			table, n))
+		is.NoErr(err)
+	}
+
+	// Capture the exact id set the snapshot must cover BEFORE inserting any
+	// post-crash CDC sentinel row.
+	wantIDs := snapshotTableIDs(ctx, t, pool, table)
+	seen := make(map[int64]bool)
+
+	// --- Run 1: partial snapshot, then "crash" (teardown). ---
+	i1, err := NewCombinedIterator(ctx, pool, Config{
+		Position:        opencdc.Position{},
+		Tables:          []string{table},
+		TableKeys:       map[string]string{table: "id"},
+		PublicationName: table,
+		SlotName:        table,
+		WithSnapshot:    true,
+		BatchSize:       2,
+	})
+	is.NoErr(err)
+
+	var lastPos opencdc.Position
+	for n := 0; n < 3; n++ { // read only a few batches, leaving the snapshot unfinished
+		recs, err := i1.NextN(ctx, 2)
+		is.NoErr(err)
+		for _, r := range recs {
+			pos, err := position.ParseSDKPosition(r.Position)
+			is.NoErr(err)
+			is.Equal(pos.Type, position.TypeSnapshot)
+			_, tagged := r.Metadata[snapshot.MetadataSnapshotResumed]
+			is.True(!tagged) // first run must never be labeled resumed
+			seen[recordID(t, r)] = true
+			lastPos = r.Position
+			is.NoErr(i1.Ack(ctx, r.Position))
+		}
+	}
+	is.NoErr(i1.Teardown(ctx))
+
+	// The persisted resume position is snapshot-typed with real progress.
+	pp, err := position.ParseSDKPosition(lastPos)
+	is.NoErr(err)
+	is.Equal(pp.Type, position.TypeSnapshot)
+
+	// Insert one post-crash row: it is NOT part of the snapshot set and serves as
+	// a CDC sentinel so the resumed run cleanly signals "snapshot done -> CDC"
+	// (a CDC-typed position) instead of blocking on an idle stream.
+	_, err = pool.Exec(ctx, fmt.Sprintf(
+		`INSERT INTO %q (key, column1, column2, column3, column4, column5, column6, column7, "UppercaseColumn1")
+			VALUES ('cdc-sentinel', 'r', 1, false, 1.1, 1, '{"a":1}', '{"a":1}', 1)`,
+		table))
+	is.NoErr(err)
+
+	// --- Run 2: resume from the persisted snapshot position. ---
+	i2, err := NewCombinedIterator(ctx, pool, Config{
+		Position:        lastPos,
+		Tables:          []string{table},
+		TableKeys:       map[string]string{table: "id"},
+		PublicationName: table,
+		SlotName:        table,
+		WithSnapshot:    true,
+		BatchSize:       4,
+	})
+	is.NoErr(err)
+
+	sawResumed := false
+drain:
+	for {
+		recs, err := i2.NextN(ctx, 4)
+		is.NoErr(err)
+		for _, r := range recs {
+			pos, err := position.ParseSDKPosition(r.Position)
+			is.NoErr(err)
+			if pos.Type == position.TypeCDC {
+				// Snapshot fully drained; CDC has taken over. Stop.
+				is.NoErr(i2.Ack(ctx, r.Position))
+				break drain
+			}
+			is.Equal(r.Metadata[snapshot.MetadataSnapshotResumed], "true")
+			is.True(pos.SnapshotLowWatermarkLSN != "") // watermark carried across resume
+			seen[recordID(t, r)] = true
+			is.NoErr(i2.Ack(ctx, r.Position))
+			sawResumed = true
+		}
+	}
+	is.True(sawResumed)
+
+	// No gap: every id present at snapshot start was read across the two runs.
+	for id := range wantIDs {
+		is.True(seen[id])
+	}
+
+	is.NoErr(i2.Teardown(ctx))
+	is.NoErr(Cleanup(context.Background(), CleanupConfig{
+		URL:             pool.Config().ConnString(),
+		SlotName:        table,
+		PublicationName: table,
+	}))
+}
+
+// TestCombinedIterator_ResumeAtSwitchoverBoundary is DBZ-3 Area 1 acceptance
+// criterion 10 (switchover-boundary chaos): the snapshot fully drains (every
+// FetchWorker reaches end-of-cursor) but the connector is torn down BEFORE the
+// snapshot->CDC handoff runs, so the persisted position is still snapshot-typed.
+// On resume the connector must reconstruct the (now empty-range) snapshot,
+// short-circuit to done, and transition cleanly to CDC from the low watermark
+// with no gap and no duplicate. It asserts a row inserted after the crash is
+// delivered exactly once via CDC on resume.
+//
+// DB-gated; WRITTEN-BUT-UNRUN where docker is unavailable; CI runs it.
+func TestCombinedIterator_ResumeAtSwitchoverBoundary(t *testing.T) {
+	ctx := test.Context(t)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*120)
+	defer cancel()
+	is := is.New(t)
+
+	pool := test.ConnectPool(ctx, t, test.RepmgrConnString)
+	table := test.SetupTestTable(ctx, t, pool)
+
+	wantIDs := snapshotTableIDs(ctx, t, pool, table)
+
+	// --- Run 1: drain the ENTIRE snapshot, ack it, but stop before the call that
+	// would trigger the snapshot->CDC transition. ---
+	i1, err := NewCombinedIterator(ctx, pool, Config{
+		Position:        opencdc.Position{},
+		Tables:          []string{table},
+		TableKeys:       map[string]string{table: "id"},
+		PublicationName: table,
+		SlotName:        table,
+		WithSnapshot:    true,
+		BatchSize:       2,
+	})
+	is.NoErr(err)
+
+	seen := make(map[int64]bool)
+	var lastPos opencdc.Position
+	for len(seen) < len(wantIDs) {
+		recs, err := i1.NextN(ctx, 2)
+		is.NoErr(err)
+		for _, r := range recs {
+			pos, err := position.ParseSDKPosition(r.Position)
+			is.NoErr(err)
+			is.Equal(pos.Type, position.TypeSnapshot) // still snapshot: no transition yet
+			seen[recordID(t, r)] = true
+			lastPos = r.Position
+			is.NoErr(i1.Ack(ctx, r.Position))
+		}
+	}
+	// Stop here: every snapshot row read+acked, but useCDCIterator never ran.
+	is.NoErr(i1.Teardown(ctx))
+
+	pp, err := position.ParseSDKPosition(lastPos)
+	is.NoErr(err)
+	is.Equal(pp.Type, position.TypeSnapshot) // crash is exactly at the boundary
+
+	// Insert a row after the crash: it must arrive via CDC on resume (never lost),
+	// and only once (never also re-emitted as a phantom snapshot record).
+	_, err = pool.Exec(ctx, fmt.Sprintf(
+		`INSERT INTO %q (key, column1, column2, column3, column4, column5, column6, column7, "UppercaseColumn1")
+			VALUES ('post-crash', 'r', 1, false, 1.1, 1, '{"a":1}', '{"a":1}', 1)`,
+		table))
+	is.NoErr(err)
+
+	// --- Run 2: resume; must transition cleanly to CDC and deliver the new row. ---
+	i2, err := NewCombinedIterator(ctx, pool, Config{
+		Position:        lastPos,
+		Tables:          []string{table},
+		TableKeys:       map[string]string{table: "id"},
+		PublicationName: table,
+		SlotName:        table,
+		WithSnapshot:    true,
+		BatchSize:       2,
+	})
+	is.NoErr(err)
+
+	var cdcCount int
+	for retries := 0; retries < 20 && cdcCount == 0; retries++ {
+		recs, err := i2.NextN(ctx, 2)
+		is.NoErr(err)
+		for _, r := range recs {
+			pos, err := position.ParseSDKPosition(r.Position)
+			is.NoErr(err)
+			// No phantom snapshot record must be emitted for an already-completed
+			// snapshot at the switchover boundary.
+			is.Equal(pos.Type, position.TypeCDC)
+			cdcCount++
+			is.NoErr(i2.Ack(ctx, r.Position))
+		}
+	}
+	is.True(cdcCount >= 1) // the post-crash row arrived via CDC (no gap)
+
+	is.NoErr(i2.Teardown(ctx))
+	is.NoErr(Cleanup(context.Background(), CleanupConfig{
+		URL:             pool.Config().ConnString(),
+		SlotName:        table,
+		PublicationName: table,
+	}))
 }

--- a/source/logrepl/handler.go
+++ b/source/logrepl/handler.go
@@ -58,9 +58,12 @@ type CDCHandler struct {
 	// Position{Type: CDC, LastLSN} for every record and silently drop those
 	// fields the instant the snapshot->CDC handoff completes — see the DBZ-3
 	// design doc's "Position carry-forward is an implementation requirement"
-	// section (acceptance criterion 11). It is written once at construction and
-	// only read thereafter (all reads happen on the single subscription goroutine
-	// via Handle), so it needs no locking.
+	// section (acceptance criterion 11). It is written at construction and may be
+	// re-seeded exactly once more at the snapshot->CDC handoff via
+	// setBasePositionLowWatermark (see there for why the handoff re-seed is
+	// required and why it is race-free). All reads happen on the single
+	// subscription goroutine via Handle, which does not start until
+	// StartSubscriber; both writes happen before that, so it needs no locking.
 	basePosition position.Position
 }
 
@@ -357,6 +360,17 @@ func (h *CDCHandler) buildPosition(lsn pglogrepl.LSN) opencdc.Position {
 		LastLSN:                 lsn.String(),
 		SnapshotLowWatermarkLSN: h.basePosition.SnapshotLowWatermarkLSN,
 	}.ToSDKPosition()
+}
+
+// setBasePositionLowWatermark re-seeds the SnapshotLowWatermarkLSN carried
+// forward by buildPosition (DBZ-3 Area 1, acceptance criterion 11). It is called
+// once, at the snapshot->CDC handoff, before the subscription goroutine starts —
+// see CDCIterator.SetSnapshotLowWatermarkLSN for the concurrency contract and the
+// reason the handoff re-seed is load-bearing (on a first run the watermark is not
+// known when the handler is constructed, only after the slot is created, so it
+// must be re-applied before CDC positions are built).
+func (h *CDCHandler) setBasePositionLowWatermark(lsn string) {
+	h.basePosition.SnapshotLowWatermarkLSN = lsn
 }
 
 // updateAvroSchema generates and stores avro schema based on the relation's row

--- a/source/logrepl/handler_test.go
+++ b/source/logrepl/handler_test.go
@@ -131,6 +131,50 @@ func TestCDCHandler_buildPosition_CarriesForwardWatermark(t *testing.T) {
 	}
 }
 
+// TestCDCHandler_HandoffReseed_FirstRunSameRun is the regression test for the
+// load-bearing DBZ-3 Area 1 fix that slice 1 could not cover: the FIRST-run
+// same-run snapshot->CDC handoff. On a first run the snapshot low watermark is
+// captured only when the replication slot is created — which happens after the
+// CDCHandler is constructed — so the handler starts with an EMPTY watermark
+// (unlike the resumed case slice 1 tested, where the persisted position already
+// carries it). Without the handoff re-seed, the watermark would ride snapshot
+// records but be silently dropped the instant CDC took over, so criterion 11
+// would hold only for a resume and regress intermittently on a first run.
+//
+// This exercises the exact seam CombinedIterator.useCDCIterator uses
+// (CDCIterator.SetSnapshotLowWatermarkLSN -> setBasePositionLowWatermark) and
+// asserts EVERY subsequent CDC position carries the watermark, not just the first.
+func TestCDCHandler_HandoffReseed_FirstRunSameRun(t *testing.T) {
+	is := is.New(t)
+
+	const watermark = "0/1600000"
+	// First-run handler: seeded from an initial (empty) start position exactly as
+	// NewCDCIterator seeds it before the slot — and thus the watermark — exists.
+	h := &CDCHandler{basePosition: position.Position{Type: position.TypeInitial}}
+
+	// Before the handoff re-seed, buildPosition cannot carry a watermark. This
+	// pins the gap the re-seed closes (and would catch a regression that seeded
+	// the watermark too early or not at all).
+	before, err := position.ParseSDKPosition(h.buildPosition(0x1600010))
+	is.NoErr(err)
+	is.Equal(before.SnapshotLowWatermarkLSN, "")
+
+	// Simulate the handoff through the public iterator seam CombinedIterator uses.
+	it := &CDCIterator{handler: h}
+	it.SetSnapshotLowWatermarkLSN(watermark)
+
+	// After the handoff, the watermark rides EVERY CDC position, not just the first.
+	lsns := []pglogrepl.LSN{0x1600020, 0x1600030, 0x1600040}
+	for _, lsn := range lsns {
+		got, err := position.ParseSDKPosition(h.buildPosition(lsn))
+		is.NoErr(err)
+		is.Equal(got.Type, position.TypeCDC)
+		is.Equal(got.LastLSN, lsn.String())
+		is.Equal(got.SnapshotLowWatermarkLSN, watermark)
+		is.Equal(got.Version, position.CurrentPositionVersion)
+	}
+}
+
 // newRelationSetForToastTests builds a RelationSet with a single 3-column
 // relation (id, small_col, big_col) registered under RelationID 1, used by
 // the handleUpdate invariant-6 regression tests below.

--- a/source/logrepl/internal/subscription.go
+++ b/source/logrepl/internal/subscription.go
@@ -43,6 +43,18 @@ type Subscription struct {
 	StatusTimeout time.Duration
 	TXSnapshotID  string
 
+	// RestartLSN is the replication slot's restart_lsn as read at subscription
+	// creation. When the slot was freshly created on this run (TXSnapshotID is
+	// non-empty), this is the slot's consistent point — the WAL position the
+	// exported snapshot is consistent with — and it is the snapshot low watermark
+	// used by DBZ-3 Area 1's resumable-snapshot reconciliation. On a resume (the
+	// slot already existed, TXSnapshotID is empty) this reflects the slot's
+	// current restart_lsn, which may have advanced past the original snapshot
+	// point; callers must therefore only treat it as the low watermark when
+	// TXSnapshotID is non-empty and otherwise carry the persisted watermark
+	// forward from the position.
+	RestartLSN pglogrepl.LSN
+
 	conn *pgxpool.Conn
 	pool *pgxpool.Pool
 
@@ -132,6 +144,7 @@ func CreateSubscription(
 		Handler:       h,
 		StatusTimeout: 10 * time.Second,
 		TXSnapshotID:  result.SnapshotName,
+		RestartLSN:    slotInfo.RestartLSN,
 
 		conn: conn,
 		pool: pool,

--- a/source/snapshot/iterator.go
+++ b/source/snapshot/iterator.go
@@ -30,6 +30,15 @@ import (
 
 var ErrIteratorDone = errors.New("snapshot complete")
 
+// MetadataSnapshotResumed is set to "true" on every snapshot record emitted by a
+// snapshot that is resuming from a prior run's persisted progress (DBZ-3 Area 1).
+// It lets a downstream consumer distinguish a resumed-snapshot record — read
+// without the transaction-snapshot pin, whose point-in-time consistency is
+// guaranteed only by CDC replay reconciliation, not by snapshot isolation — from
+// a first-run snapshot record read under a pinned exported snapshot. See the
+// DBZ-3 design doc, "Area 1: Resumable snapshot consistency".
+const MetadataSnapshotResumed = "postgres.snapshot.resumed"
+
 type Config struct {
 	Position       opencdc.Position
 	Tables         []string
@@ -37,6 +46,15 @@ type Config struct {
 	TXSnapshotID   string
 	FetchSize      int
 	WithAvroSchema bool
+
+	// SnapshotResumed indicates this snapshot is resuming from a prior run's
+	// persisted progress (the start position was already snapshot-typed). When
+	// true, every emitted record is tagged with MetadataSnapshotResumed. The
+	// resumed read runs without the transaction-snapshot pin (it cannot be
+	// re-acquired across a restart — see the design doc's Finding 1), so its
+	// consistency degrades to "possibly-duplicate, never-gap" reconciled by CDC
+	// replay; the tag makes that observable rather than silent.
+	SnapshotResumed bool
 }
 
 type Iterator struct {
@@ -154,6 +172,11 @@ func (i *Iterator) buildRecord(d FetchData) opencdc.Record {
 	pos := i.lastPosition.ToSDKPosition()
 	metadata := make(opencdc.Metadata)
 	metadata[opencdc.MetadataCollection] = d.Table
+	if i.conf.SnapshotResumed {
+		// DBZ-3 Area 1: tag records emitted by a resumed (unpinned) snapshot so
+		// the degraded, replay-reconciled consistency is observable downstream.
+		metadata[MetadataSnapshotResumed] = "true"
+	}
 
 	rec := sdk.Util.Source.NewRecordSnapshot(pos, metadata, d.Key, d.Payload)
 	if i.conf.WithAvroSchema {

--- a/source/snapshot/iterator_test.go
+++ b/source/snapshot/iterator_test.go
@@ -26,6 +26,55 @@ import (
 	"github.com/matryer/is"
 )
 
+// Test_Iterator_buildRecord_ResumedTag is a white-box unit test (no DB) for the
+// DBZ-3 Area 1 resumed-snapshot tag. When the iterator was constructed for a
+// resume (SnapshotResumed=true), every emitted record must carry
+// postgres.snapshot.resumed=true and carry the captured low watermark forward on
+// its position; a first-run snapshot (SnapshotResumed=false) must NOT carry the
+// tag, so a resumed record is distinguishable downstream and a first-run record
+// is never mislabeled.
+func Test_Iterator_buildRecord_ResumedTag(t *testing.T) {
+	const watermark = "0/1A2B3C4"
+	fd := FetchData{
+		Key:      opencdc.StructuredData{"id": int64(1)},
+		Payload:  opencdc.StructuredData{"id": int64(1), "name": "x"},
+		Position: position.SnapshotPosition{LastRead: 1, SnapshotEnd: 10},
+		Table:    "orders",
+	}
+
+	t.Run("resumed tags every record and carries watermark", func(t *testing.T) {
+		is := is.New(t)
+		i := &Iterator{
+			conf: Config{SnapshotResumed: true},
+			lastPosition: position.Position{
+				Snapshots:               make(position.SnapshotPositions),
+				SnapshotLowWatermarkLSN: watermark,
+			},
+		}
+
+		rec := i.buildRecord(fd)
+		is.Equal(rec.Metadata[MetadataSnapshotResumed], "true")
+		is.Equal(rec.Metadata[opencdc.MetadataCollection], "orders")
+
+		pos, err := position.ParseSDKPosition(rec.Position)
+		is.NoErr(err)
+		is.Equal(pos.Type, position.TypeSnapshot)
+		is.Equal(pos.SnapshotLowWatermarkLSN, watermark) // watermark rides snapshot positions
+	})
+
+	t.Run("first run is not tagged resumed", func(t *testing.T) {
+		is := is.New(t)
+		i := &Iterator{
+			conf:         Config{SnapshotResumed: false},
+			lastPosition: position.Position{Snapshots: make(position.SnapshotPositions)},
+		}
+
+		rec := i.buildRecord(fd)
+		_, ok := rec.Metadata[MetadataSnapshotResumed]
+		is.True(!ok) // a first-run snapshot record must never be labeled resumed
+	})
+}
+
 func Test_Iterator_NextN(t *testing.T) {
 	var (
 		ctx   = test.Context(t)


### PR DESCRIPTION
## What & why

DBZ-3 Area 1 (resumable-snapshot low watermark), building on slice 1 (versioned position format, #318). Advances roadmap item **v0.20 WS7 — Postgres CDC parity**, design doc `docs/design-documents/20260724-dbz3-postgres-cdc-parity.md` (Area 1 + acceptance criteria 2, 10, 11).

A resumable snapshot must reconcile against a known WAL point (the "low watermark") so a mid-snapshot crash resumes without a gap and CDC replay dedups the overlap. This slice:

1. **Captures the low watermark** — the freshly-created slot's `restart_lsn` becomes the watermark (only when this run created the slot, `TXSnapshotID != ""`); on a resume the persisted watermark is authoritative and is never overwritten.
2. **Re-seeds `handler.basePosition` at the in-run snapshot→CDC handoff** (`useCDCIterator`, before `StartSubscriber`). This is the load-bearing fix slice 1's review flagged: on a first run the watermark is known only *after* the slot is created — after the CDC handler was constructed — so without the re-seed the watermark rides snapshot records but is dropped the instant CDC takes over (criterion 11 holds for a resume but silently regresses on a first-run same-run handoff).
3. **Tags resumed-snapshot records** `postgres.snapshot.resumed=true` — the resumed read runs without the transaction-snapshot pin, so its consistency degrades to possibly-duplicate/never-gap reconciled by CDC replay; the tag makes that observable instead of silent.

## Risk tier: **Tier 1 (data path)**

Touches position/watermark logic on the CDC path. Human sign-off required; not merging on automated review alone.

## Failure-mode analysis

- **Crash mid-snapshot** → resume reads persisted watermark (not the possibly-advanced slot `restart_lsn`), re-reads unpinned, dedups via CDC replay from the watermark. No gap (at-least-once), possible dup (acceptable, tagged). Covered by `TestCombinedIterator_ResumeMidSnapshot_ResumedTag` (criterion 2, DB-gated → CI).
- **Crash at the switchover boundary** → resume transitions cleanly to CDC, no phantom snapshot record, post-crash insert arrives via CDC. Covered by `TestCombinedIterator_ResumeAtSwitchoverBoundary` (criterion 10, DB-gated → CI).
- **First-run same-run handoff drops watermark** (the regression this closes) → `TestCDCHandler_HandoffReseed_FirstRunSameRun` asserts empty-before-reseed / carried-on-every-position-after.
- **Early WAL pruning (invariant 1)** → not introduced: slot `confirmed_flush_lsn` advances only via `CDCIterator.Ack` → `SendStandbyStatusUpdate`, which cannot run until `StartSubscriber`, strictly after the handoff/re-seed. The re-seed touches only in-process position state. Enforcement comment at `combined.go` useCDCIterator.
- **Race on `basePosition`** → re-seed happens before the subscription goroutine (the only reader, via `Handle`) starts; single-writer-before-start, no lock needed.
- **Rollback** → additive position field (slice 1's format, `omitempty`); a downgrade reads it as legacy (Version 0 path). No serialized-format break beyond slice 1's already-shipped one.

## Which metric/alert would show a regression

Resumed-without-pin observability (`postgres_snapshot_resumed_without_pin_total`, criterion 8) is deliberately a **later** Area-1 slice; this slice ships the `postgres.snapshot.resumed` record tag as the interim signal. A gap regression would surface as missing rows downstream / an at-least-once acceptance-test failure.

## Tests

- Unit (local, `-race`, no docker): `TestCDCHandler_HandoffReseed_FirstRunSameRun`, `Test_Iterator_buildRecord_ResumedTag` (both tag directions + watermark ride), plus slice-1 carry-forward — all green.
- DB-gated (CI): the two resume/switchover chaos tests above — **written, compile+vet clean, not runnable locally (no docker); must be green in CI before merge.**
- `go build` / `go vet` / `gofumpt` / `golangci-lint` — clean locally.

## Adversarial self-review

Re-read for: nil deref on `LowWatermarkLSN()`/`TXSnapshotID()` before `StartSubscriber` (safe — `sub` populated in `NewCDCIterator`); `pos.ToSDKPosition()` swap dropping the snapshot cursor (safe — full `Snapshots` preserved, only additive watermark added); handoff re-seed ordering vs the subscription goroutine (safe — re-seed strictly before `StartSubscriber`); pure-CDC path correctly skips the re-seed. No open uncertainty about behavior under failure.

## Not in this slice (slicing note)

Area-1 observability surface (criterion 8), slot-lost-on-resume fast-fail; Area 2 (DDL/SchemaHistory + schemaDrift policy), heartbeats, transaction-boundary metadata, benchi, runbooks. Each its own design-referenced slice; Area 2 recommended split further (relation-diff → drift policy → Finding-2 decode-site).
