### PR TITLE
docs(design): record DeVaris's four DBZ-3 decisions

### DIFF
--- a/docs/design-documents/20260724-dbz3-postgres-cdc-parity.md
+++ b/docs/design-documents/20260724-dbz3-postgres-cdc-parity.md
@@ -540,6 +540,38 @@ before this ships, each with symptom → diagnosis → remediation, per the exis
   table alongside the slot/publication on connector deletion, defaulting to leave-it-in-place to
   avoid surprising drops of an operator-visible table).
 
+## Decisions (DeVaris, 2026-08-03)
+
+All four open questions below are RESOLVED. Recorded here rather than in a new document because
+they answer questions this doc posed; the questions are kept intact underneath so the reasoning
+that produced each answer stays readable.
+
+1. **`logrepl.schemaDrift.policy` default = `halt`.** Confirmed: safety over silent continuity.
+   **This is a BREAKING CHANGE** and must ship with a migration note and a deprecation plan per
+   CLAUDE.md — pipelines upgrading to a DBZ-3 connector version will, for the first time, stop on
+   a DDL that previously passed through silently. The note must say plainly what changed, how to
+   restore the old behaviour (`evolve`), and why the default moved (silent drift is an
+   invariant-6 violation). Acceptance: the note exists and is linked from the release notes, not
+   buried in a changelog line.
+
+2. **Rename detection: NOT built in this workstream.** Confirmed. `pgoutput` cannot distinguish a
+   rename from drop+add, and the `REPLICA IDENTITY FULL` heuristic can still be wrong. Ship
+   drop+add — correct, noisier. This is a decision that the heuristic is not worth its complexity,
+   not a deferral; revisit only on a concrete user report.
+
+3. **Heartbeat table: keep `_conduit_heartbeat`; defer collision handling.** Confirmed. The table
+   stays visible to any other consumer of the same publication. Collision with a coexisting
+   Debezium heartbeat table during a migration-in-progress is real but belongs to the KC-migration
+   compatibility-report path. Carry it forward there so it is not lost.
+
+4. **Benchi: connector-local measurement, `postgres→log` reference.** Confirmed. Two reasons this
+   does NOT block on the repo-level benchi harness: that harness was retracted as unfit for engine
+   comparison (ConduitIO/conduit#2748 — its metric is not comparable across engines and its A/A
+   noise floor exceeded the effect), and `postgres→s3` is blocked on conduit-connector-s3#963
+   (MinIO checksum). A connector-local before/after on the heartbeat and resumed-snapshot-tagging
+   hot paths answers criterion 6 without inheriting the engine-benchmark problem. **Any number
+   reported must cite an A/A floor beside it**, per the methodology in that retraction.
+
 ## Open questions for DeVaris
 
 1. **Default for `logrepl.schemaDrift.policy`.** This doc proposes `halt` as the safe default


### PR DESCRIPTION
Records DeVaris's answers to the four open questions the DBZ-3 design doc posed (2026-08-03), unblocking WS7 implementation. The original questions are kept intact beneath the decisions so the reasoning behind each answer stays readable.

| # | Question | Decision |
| --- | --- | --- |
| 1 | `logrepl.schemaDrift.policy` default | **`halt`** — safety over silent continuity |
| 2 | Rename detection | **Not built** — ship drop+add |
| 3 | Heartbeat table naming | **Keep `_conduit_heartbeat`**, defer collision handling |
| 4 | Benchi reference | **Connector-local**, `postgres→log` |

## The one that needs follow-through: #1 is a breaking change

`halt`-by-default means pipelines upgrading to a DBZ-3 connector version will, **for the first time, stop on a DDL that previously passed through silently.** Per CLAUDE.md that requires a migration note and a deprecation plan.

**Neither the v0.20 execution plan nor the completion plan named this as breaking.** It surfaced during the adversarial review of the completion plan. The acceptance bar recorded here is that the note exists and is *linked from the release notes* — not buried in a changelog line — and says plainly what changed, how to restore the old behaviour (`evolve`), and why the default moved (silent drift is an invariant-6 violation).

## Note on #4

Deliberately **not** blocked on the repo-level benchi harness: that harness was retracted as unfit for engine comparison in ConduitIO/conduit#2748 (its metric is not comparable across engines — v1 observes once per acked record, arch-v2 observes at both source read and destination ack — and its A/A noise floor exceeded the effect being measured). `postgres→s3` was also unavailable as a reference, being blocked on conduit-connector-s3#963 (MinIO checksum).

A connector-local before/after on the heartbeat and resumed-snapshot-tagging hot paths satisfies acceptance criterion 6 without inheriting the engine-benchmark problem. **Any number reported must cite an A/A floor beside it**, per the methodology committed in that retraction.

## Formatting

Wrapped to this file's existing ~100-column style rather than markdownlint's 80. The doc has 379 pre-existing MD013 violations and markdownlint does not run in this repo's CI, so rewrapping would have been diff noise for no gain.