### PR TITLE
feat(source): DBZ-3 Area 1 step 3 — announce a resumed snapshot's degraded mode

### DIFF
--- a/source/snapshot/iterator.go
+++ b/source/snapshot/iterator.go
@@ -90,6 +90,8 @@ func NewIterator(ctx context.Context, db *pgxpool.Pool, c Config) (*Iterator, er
 		lastPosition: p,
 	}
 
+	emitResumeWarning(ctx, c.SnapshotResumed, p)
+
 	if err := i.initFetchers(ctx); err != nil {
 		return nil, fmt.Errorf("failed to initialize table fetchers: %w", err)
 	}
@@ -226,4 +228,40 @@ func (i *Iterator) startWorkers() {
 		<-i.workersTomb.Dead()
 		close(i.data)
 	}()
+}
+
+// emitResumeWarning announces a resumed (unpinned) snapshot once per run.
+//
+// Extracted so the decision is directly testable — see
+// Test_Iterator_ResumeWarning_NotSilent.
+// DBZ-3 Area 1, step 3: make the degraded mode observable, not silent.
+//
+// A resumed snapshot cannot re-acquire the original TXSnapshotID, so it
+// reads WITHOUT the transaction-snapshot pin the first run had. That is
+// deliberate and safe — CDC replays the unpinned window afterwards because
+// the stream cannot prune past the low watermark until the snapshot
+// completes, so the weakened isolation degrades to possible duplicates,
+// never a gap. But "safe because something else compensates" is exactly the
+// kind of guarantee that must not be invisible: an operator watching a long
+// resumed snapshot otherwise has no way to tell it is in replay-reconciled
+// mode rather than the same-guarantee-as-fresh mode.
+//
+// Per-record metadata (MetadataSnapshotResumed) already marks the records.
+// This is the once-per-run counterpart, so the condition is visible in logs
+// at the moment it is entered rather than only by inspecting record
+// metadata downstream.
+func emitResumeWarning(ctx context.Context, resumed bool, p position.Position) {
+	if !resumed {
+		return
+	}
+
+	sdk.Logger(ctx).Warn().
+		Str("snapshot_low_watermark_lsn", p.SnapshotLowWatermarkLSN).
+		Int("tables_resuming", len(p.Snapshots)).
+		Msg("resuming snapshot WITHOUT a transaction-snapshot pin: the original " +
+			"TXSnapshotID cannot be re-acquired across a restart. Consistency for the " +
+			"resumed window is provided by CDC replay (the stream cannot prune past the " +
+			"low watermark until the snapshot completes), so the degradation is possible " +
+			"duplicate delivery, never a gap. Records emitted by this run carry " +
+			"postgres.snapshot.resumed=true")
 }

--- a/source/snapshot/iterator_test.go
+++ b/source/snapshot/iterator_test.go
@@ -15,8 +15,10 @@
 package snapshot
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +26,7 @@ import (
 	"github.com/conduitio/conduit-connector-postgres/source/position"
 	"github.com/conduitio/conduit-connector-postgres/test"
 	"github.com/matryer/is"
+	"github.com/rs/zerolog"
 )
 
 // Test_Iterator_buildRecord_ResumedTag is a white-box unit test (no DB) for the
@@ -240,4 +243,40 @@ func Test_Iterator_NextN(t *testing.T) {
 		is.True(err != nil)
 		is.Equal(err.Error(), "n must be greater than 0, got -1")
 	})
+}
+
+// Test_Iterator_ResumeWarning_NotSilent covers DBZ-3 Area 1 step 3: a resumed
+// (unpinned) snapshot must announce itself once per run, not only per record.
+//
+// The per-record MetadataSnapshotResumed tag and this warning answer different
+// questions. The tag tells a downstream consumer "this record came from a
+// degraded read". The warning tells the operator "this run is in degraded mode"
+// at the moment it starts — the only signal available before any record has been
+// emitted, which on a long resumed snapshot is exactly when someone is looking.
+// Without it the condition stays invisible until records land, which is the
+// silence the design explicitly rules out.
+func Test_Iterator_ResumeWarning_NotSilent(t *testing.T) {
+	is := is.New(t)
+
+	pos := position.Position{
+		Type:                    position.TypeSnapshot,
+		Snapshots:               position.SnapshotPositions{"tbl": {}},
+		SnapshotLowWatermarkLSN: "0/1A2B3C4",
+	}
+
+	// Resumed run: must warn, and must carry the low watermark so an operator
+	// can correlate the message with the replication slot.
+	var buf bytes.Buffer
+	ctx := zerolog.New(&buf).WithContext(context.Background())
+	emitResumeWarning(ctx, true, pos)
+	out := buf.String()
+	is.True(strings.Contains(out, "WITHOUT a transaction-snapshot pin"))
+	is.True(strings.Contains(out, "0/1A2B3C4"))
+
+	// First run: must NOT warn. A signal that fires on every start is noise,
+	// and operators learn to ignore noise.
+	buf.Reset()
+	ctx = zerolog.New(&buf).WithContext(context.Background())
+	emitResumeWarning(ctx, false, pos)
+	is.Equal(buf.String(), "")
 }


### PR DESCRIPTION
**Tier 1** (data path — observability of a degraded consistency mode). Completes **DBZ-3 Area 1** (v0.20 WS7).

## What was missing

Steps 1 and 2 landed in #319: the low watermark is captured and carried, and every record emitted by a resumed run is tagged `postgres.snapshot.resumed=true`. **Step 3 did not** — and the resume was entirely silent at the run level.

A resumed snapshot cannot re-acquire the original `TXSnapshotID`, so it reads **without** the transaction-snapshot pin the first run had. That is deliberate and safe: CDC replays the unpinned window afterwards, because the stream cannot prune past the low watermark until the snapshot completes. The weakened isolation degrades to possible duplicates, never a gap.

But "safe because something else compensates" is exactly the kind of guarantee that must not be invisible. The design says so directly:

> the honest fix for Finding 1: not eliminating the accidental-correctness path … but **bounding it, testing it, and never letting it be silent**.

## Why a warning as well as the per-record tag

They answer different questions. The tag tells a downstream consumer *"this record came from a degraded read."* The warning tells the operator *"this run is in degraded mode"* **at the moment it starts** — the only signal available before any record has been emitted, which on a long resumed snapshot is precisely when someone is looking.

It carries the low watermark LSN (so it can be correlated with the replication slot) and the number of resuming tables. It fires **only** on a resume: a signal that fires on every start is noise, and operators learn to ignore noise. The test pins both directions.

## Testing

`emitResumeWarning` is extracted rather than inlined so the decision is directly testable without a database. **Verified mutation-sensitive:** suppressing the warning fails the test.

## What this deliberately is not

The full operator-API observability surface in the design — snapshot progress, replication lag, heartbeat staleness, schema-drift decisions — is **not** this PR. It depends on heartbeats and DDL reconstruction, neither of which is built yet. `resumedWithoutPin` is the one field of that surface Area 1 owns and that can stand alone today.

## Checks

Unit suites green under `-race`. Two pre-existing conditions in this tree, both verified identical with the change stashed:

- CDC/`logrepl` integration tests fail on missing Postgres (`connection refused` on 5433) — 11 failures either way.
- `golangci-lint`: `gosec` in `source/config_test.go`, two `nolintlint` in `source/logrepl/cdc_test.go`.

## Next in WS7

Area 2 (DDL reconstruction from `pgoutput`) is the remaining hard core, and now carries DBZ-2's deferrals too — that suite explicitly deferred DDL-mid-stream/schema-drift (**invariant 6**) and real handoff atomicity to DBZ-3. Heartbeats, transaction-boundary metadata, and the rest of the observability surface follow.

The four design open questions were answered and merged in #320 — `halt` default (a **breaking change** needing a migration note), no rename detection, `_conduit_heartbeat` kept, and connector-local benchi against `postgres→log`.