### PR TITLE
feat(logrepl): DBZ-3 Area 2 step 1 — detect schema drift by diffing RelationMessages

### DIFF
--- a/source/logrepl/internal/schemadiff.go
+++ b/source/logrepl/internal/schemadiff.go
@@ -1,0 +1,207 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pglogrepl"
+)
+
+// DBZ-3 Area 2, step 1: detect schema drift by diffing successive
+// RelationMessages for the same relation ID.
+//
+// pgoutput never carries DDL statements — unlike the MySQL binlog, which
+// carries the original ALTER TABLE text — so the only signal that a table's
+// shape changed is that Postgres sends a fresh RelationMessage before the first
+// record using the new shape. RelationSet.Add previously overwrote the cached
+// relation silently, which is precisely how a schema change reached the record
+// path with nobody deciding anything about it (invariant 6: schema handling
+// never silently mangles data).
+//
+// Column identity is (Name, DataType, TypeModifier), matching how the Avro
+// schema is already derived per column. Position is deliberately NOT part of
+// identity: a column added in the middle shifts every later column's position
+// without changing any of them.
+
+// ColumnChangeKind classifies one column-level difference.
+type ColumnChangeKind string
+
+const (
+	// ColumnAdded is a column present after but not before. Widening.
+	ColumnAdded ColumnChangeKind = "added"
+	// ColumnDropped is a column present before but not after. Narrowing —
+	// downstream consumers may already depend on it.
+	ColumnDropped ColumnChangeKind = "dropped"
+	// ColumnTypeChanged is a column whose name persists but whose DataType or
+	// TypeModifier differs. May be widening (varchar(10)->varchar(20)) or
+	// narrowing (bigint->int); this layer reports the change and does not judge
+	// compatibility, which is the policy layer's job.
+	ColumnTypeChanged ColumnChangeKind = "type_changed"
+)
+
+// ColumnChange is a single difference between two shapes of one relation.
+type ColumnChange struct {
+	Kind ColumnChangeKind
+	Name string
+
+	// OldDataType/OldTypeModifier are set for dropped and type_changed.
+	OldDataType     uint32
+	OldTypeModifier int32
+	// NewDataType/NewTypeModifier are set for added and type_changed.
+	NewDataType     uint32
+	NewTypeModifier int32
+}
+
+// String renders one change in the form an operator-facing error uses.
+func (c ColumnChange) String() string {
+	switch c.Kind {
+	case ColumnAdded:
+		return fmt.Sprintf("column %q added (type %d)", c.Name, c.NewDataType)
+	case ColumnDropped:
+		return fmt.Sprintf("column %q dropped (was type %d)", c.Name, c.OldDataType)
+	case ColumnTypeChanged:
+		return fmt.Sprintf("column %q type changed (%d/%d -> %d/%d)",
+			c.Name, c.OldDataType, c.OldTypeModifier, c.NewDataType, c.NewTypeModifier)
+	default:
+		return fmt.Sprintf("column %q changed", c.Name)
+	}
+}
+
+// SchemaDiff is the set of column changes between two shapes of one relation.
+// The zero value means no drift.
+type SchemaDiff struct {
+	RelationID uint32
+	Namespace  string
+	RelationNa string
+	Changes    []ColumnChange
+}
+
+// HasDrift reports whether anything changed.
+func (d SchemaDiff) HasDrift() bool { return len(d.Changes) > 0 }
+
+// IsNarrowing reports whether the diff removes or retypes a column, as opposed
+// to only adding.
+//
+// The distinction is load-bearing for the evolve policy: adding a column is
+// safe to accept automatically because nothing downstream can already depend on
+// it, while dropping or retyping one can break a consumer that does. Policy
+// treats those differently; see the drift policy in the DBZ-3 design doc.
+func (d SchemaDiff) IsNarrowing() bool {
+	for _, c := range d.Changes {
+		if c.Kind == ColumnDropped || c.Kind == ColumnTypeChanged {
+			return true
+		}
+	}
+	return false
+}
+
+// String renders the whole diff for an operator-facing message. Changes are
+// sorted by column name so the text is stable across runs — an error message
+// whose wording depends on map iteration order is unusable in an alert.
+func (d SchemaDiff) String() string {
+	if !d.HasDrift() {
+		return "no schema drift"
+	}
+
+	parts := make([]string, 0, len(d.Changes))
+	for _, c := range d.Changes {
+		parts = append(parts, c.String())
+	}
+	sort.Strings(parts)
+
+	return fmt.Sprintf("table %s.%s (relation %d): %s",
+		d.Namespace, d.RelationNa, d.RelationID, strings.Join(parts, "; "))
+}
+
+// diffRelations compares two shapes of the same relation.
+//
+// A rename is reported as drop+add. pgoutput's RelationMessage exposes no
+// column-OID or rename tracking, so a rename is genuinely indistinguishable
+// from dropping one column and adding another — the heuristics that could guess
+// (matching position and type, no intervening DML) can still be wrong, and
+// DeVaris confirmed on 2026-08-03 that guessing is not worth its complexity.
+// Reporting drop+add is correct and noisier; guessing would be quieter and
+// sometimes wrong.
+func diffRelations(before, after *pglogrepl.RelationMessage) SchemaDiff {
+	diff := SchemaDiff{
+		RelationID: after.RelationID,
+		Namespace:  after.Namespace,
+		RelationNa: after.RelationName,
+	}
+
+	beforeCols := make(map[string]*pglogrepl.RelationMessageColumn, len(before.Columns))
+	for _, c := range before.Columns {
+		beforeCols[c.Name] = c
+	}
+	afterCols := make(map[string]*pglogrepl.RelationMessageColumn, len(after.Columns))
+	for _, c := range after.Columns {
+		afterCols[c.Name] = c
+	}
+
+	// Iterate the message slices, not the maps, so ordering is deterministic
+	// before the sort in String().
+	for _, a := range after.Columns {
+		b, existed := beforeCols[a.Name]
+		if !existed {
+			diff.Changes = append(diff.Changes, ColumnChange{
+				Kind: ColumnAdded, Name: a.Name,
+				NewDataType: a.DataType, NewTypeModifier: a.TypeModifier,
+			})
+			continue
+		}
+		if b.DataType != a.DataType || b.TypeModifier != a.TypeModifier {
+			diff.Changes = append(diff.Changes, ColumnChange{
+				Kind: ColumnTypeChanged, Name: a.Name,
+				OldDataType: b.DataType, OldTypeModifier: b.TypeModifier,
+				NewDataType: a.DataType, NewTypeModifier: a.TypeModifier,
+			})
+		}
+	}
+
+	for _, b := range before.Columns {
+		if _, still := afterCols[b.Name]; !still {
+			diff.Changes = append(diff.Changes, ColumnChange{
+				Kind: ColumnDropped, Name: b.Name,
+				OldDataType: b.DataType, OldTypeModifier: b.TypeModifier,
+			})
+		}
+	}
+
+	return diff
+}
+
+// Update caches the relation and reports what changed relative to the previously
+// cached shape.
+//
+// It replaces Add, which overwrote silently. The first RelationMessage for a
+// relation reports no drift: there is no prior shape to compare against, and
+// treating every column as newly added on first sight would make the very first
+// message of every run look like drift. Continuity across a RESTART is a
+// separate problem — a fresh process has an empty cache and would likewise see
+// no drift — which is what the durable schema history in the position solves
+// (Area 2 step 2, not this change).
+func (rs *RelationSet) Update(r *pglogrepl.RelationMessage) SchemaDiff {
+	prev, existed := rs.relations[r.RelationID]
+	rs.relations[r.RelationID] = r
+
+	if !existed {
+		return SchemaDiff{RelationID: r.RelationID, Namespace: r.Namespace, RelationNa: r.RelationName}
+	}
+
+	return diffRelations(prev, r)
+}

--- a/source/logrepl/internal/schemadiff_test.go
+++ b/source/logrepl/internal/schemadiff_test.go
@@ -1,0 +1,191 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/matryer/is"
+)
+
+func rel(id uint32, cols ...*pglogrepl.RelationMessageColumn) *pglogrepl.RelationMessage {
+	return &pglogrepl.RelationMessage{
+		RelationID: id, Namespace: "public", RelationName: "t", Columns: cols,
+	}
+}
+
+func col(name string, dataType uint32, typeMod int32) *pglogrepl.RelationMessageColumn {
+	return &pglogrepl.RelationMessageColumn{Name: name, DataType: dataType, TypeModifier: typeMod}
+}
+
+// Test_RelationSet_Update_DetectsDrift is the core Area 2 step 1 test.
+//
+// Each case is a DDL an operator can actually run, named as such, because the
+// point of this layer is to turn "a new RelationMessage arrived" into "somebody
+// ran ALTER TABLE and here is what they did".
+func Test_RelationSet_Update_DetectsDrift(t *testing.T) {
+	const relID = 42
+
+	tests := []struct {
+		name       string
+		before     []*pglogrepl.RelationMessageColumn
+		after      []*pglogrepl.RelationMessageColumn
+		wantKinds  []ColumnChangeKind
+		wantNames  []string
+		wantNarrow bool
+	}{
+		{
+			name:      "ADD COLUMN",
+			before:    []*pglogrepl.RelationMessageColumn{col("id", 23, -1)},
+			after:     []*pglogrepl.RelationMessageColumn{col("id", 23, -1), col("email", 25, -1)},
+			wantKinds: []ColumnChangeKind{ColumnAdded}, wantNames: []string{"email"},
+			wantNarrow: false,
+		},
+		{
+			name:      "DROP COLUMN",
+			before:    []*pglogrepl.RelationMessageColumn{col("id", 23, -1), col("email", 25, -1)},
+			after:     []*pglogrepl.RelationMessageColumn{col("id", 23, -1)},
+			wantKinds: []ColumnChangeKind{ColumnDropped}, wantNames: []string{"email"},
+			wantNarrow: true,
+		},
+		{
+			name:      "ALTER COLUMN TYPE",
+			before:    []*pglogrepl.RelationMessageColumn{col("n", 23, -1)},
+			after:     []*pglogrepl.RelationMessageColumn{col("n", 20, -1)},
+			wantKinds: []ColumnChangeKind{ColumnTypeChanged}, wantNames: []string{"n"},
+			wantNarrow: true,
+		},
+		{
+			// varchar(10) -> varchar(20): same DataType, different TypeModifier.
+			// Ignoring TypeModifier would miss it entirely, and a consumer with a
+			// fixed-width schema very much cares.
+			name:      "ALTER COLUMN length only (TypeModifier)",
+			before:    []*pglogrepl.RelationMessageColumn{col("s", 1043, 14)},
+			after:     []*pglogrepl.RelationMessageColumn{col("s", 1043, 24)},
+			wantKinds: []ColumnChangeKind{ColumnTypeChanged}, wantNames: []string{"s"},
+			wantNarrow: true,
+		},
+		{
+			// A rename is indistinguishable from drop+add in pgoutput, and per
+			// the 2026-08-03 decision we report it as such rather than guess.
+			name:       "RENAME COLUMN reported as drop+add",
+			before:     []*pglogrepl.RelationMessageColumn{col("old", 25, -1)},
+			after:      []*pglogrepl.RelationMessageColumn{col("new", 25, -1)},
+			wantKinds:  []ColumnChangeKind{ColumnAdded, ColumnDropped},
+			wantNames:  []string{"new", "old"},
+			wantNarrow: true,
+		},
+		{
+			// Adding a column in the MIDDLE shifts every later column's position
+			// while changing none of them. Identity keyed on position rather than
+			// name would report the whole tail as changed.
+			name:      "ADD COLUMN in the middle does not report the shifted tail",
+			before:    []*pglogrepl.RelationMessageColumn{col("a", 23, -1), col("c", 25, -1)},
+			after:     []*pglogrepl.RelationMessageColumn{col("a", 23, -1), col("b", 16, -1), col("c", 25, -1)},
+			wantKinds: []ColumnChangeKind{ColumnAdded}, wantNames: []string{"b"},
+			wantNarrow: false,
+		},
+		{
+			name:      "no change",
+			before:    []*pglogrepl.RelationMessageColumn{col("id", 23, -1), col("email", 25, -1)},
+			after:     []*pglogrepl.RelationMessageColumn{col("id", 23, -1), col("email", 25, -1)},
+			wantKinds: nil, wantNames: nil, wantNarrow: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			is := is.New(t)
+			rs := NewRelationSet()
+
+			// First message establishes the baseline and must report nothing.
+			first := rs.Update(rel(relID, tt.before...))
+			is.True(!first.HasDrift())
+
+			got := rs.Update(rel(relID, tt.after...))
+			is.Equal(len(got.Changes), len(tt.wantKinds))
+			is.Equal(got.HasDrift(), len(tt.wantKinds) > 0)
+			is.Equal(got.IsNarrowing(), tt.wantNarrow)
+
+			gotKinds := map[ColumnChangeKind]int{}
+			gotNames := map[string]bool{}
+			for _, c := range got.Changes {
+				gotKinds[c.Kind]++
+				gotNames[c.Name] = true
+			}
+			for _, k := range tt.wantKinds {
+				is.True(gotKinds[k] > 0)
+			}
+			for _, n := range tt.wantNames {
+				is.True(gotNames[n])
+			}
+		})
+	}
+}
+
+// Test_RelationSet_Update_FirstMessageIsNotDrift pins that the very first
+// RelationMessage for a relation reports nothing.
+//
+// Getting this wrong would make every run's first message look like a full-table
+// schema change, which under the default halt policy would stop every pipeline
+// on startup.
+func Test_RelationSet_Update_FirstMessageIsNotDrift(t *testing.T) {
+	is := is.New(t)
+	rs := NewRelationSet()
+
+	d := rs.Update(rel(7, col("id", 23, -1), col("name", 25, -1)))
+	is.True(!d.HasDrift())
+	is.True(!d.IsNarrowing())
+	is.Equal(d.String(), "no schema drift")
+}
+
+// Test_RelationSet_Update_IsolatesRelations pins that drift in one table does
+// not leak into another. Relation IDs are the cache key, and a shared or
+// mis-keyed cache would report a neighbouring table's DDL against the wrong one.
+func Test_RelationSet_Update_IsolatesRelations(t *testing.T) {
+	is := is.New(t)
+	rs := NewRelationSet()
+
+	rs.Update(rel(1, col("id", 23, -1)))
+	rs.Update(rel(2, col("id", 23, -1)))
+
+	// Drift table 1 only.
+	d1 := rs.Update(rel(1, col("id", 23, -1), col("extra", 25, -1)))
+	is.True(d1.HasDrift())
+
+	// Table 2 unchanged: no drift.
+	d2 := rs.Update(rel(2, col("id", 23, -1)))
+	is.True(!d2.HasDrift())
+}
+
+// Test_SchemaDiff_String_IsStable pins that the operator-facing message is
+// deterministic. An alert whose text reorders between runs cannot be
+// deduplicated or matched, so the sort is behaviour, not cosmetics.
+func Test_SchemaDiff_String_IsStable(t *testing.T) {
+	is := is.New(t)
+	rs := NewRelationSet()
+
+	rs.Update(rel(9, col("a", 23, -1), col("b", 25, -1), col("c", 16, -1)))
+	d := rs.Update(rel(9, col("a", 23, -1), col("z", 25, -1)))
+
+	first := d.String()
+	for range 20 {
+		is.Equal(d.String(), first)
+	}
+	is.True(strings.Contains(first, "public.t"))
+	is.True(strings.Contains(first, "relation 9"))
+}


### PR DESCRIPTION
**Tier 1** (data path — invariant 6). First slice of **DBZ-3 Area 2**, the DDL-reconstruction core of WS7.

## Why this exists

`pgoutput` never carries DDL statements — unlike the MySQL binlog, which carries the original `ALTER TABLE` text. The *only* signal that a table's shape changed is that Postgres sends a fresh `RelationMessage` before the first record using the new shape.

`RelationSet.Add` overwrote the cached relation **silently**. That is exactly how a schema change reached the record path with nobody deciding anything about it.

Adds `RelationSet.Update`: caches as `Add` did, and returns a `SchemaDiff` of what changed. `Add` stays for now; call sites move in the slice that consumes the diff.

## Two deliberate design choices, both mutation-tested

**`TypeModifier` is part of column identity.** `varchar(10) → varchar(20)` is the same `DataType` with a different width, and a consumer with a fixed-width schema very much cares. Dropping it from the comparison fails the `ALTER COLUMN length only` case.

**Position is *not* part of identity.** A column added in the middle shifts every later column's position while changing none of them. Keying on position reports the whole tail as changed — verified: it fails both `ADD COLUMN in the middle` and `RENAME COLUMN`.

## A rename is reported as drop+add

`RelationMessage` exposes no column-OID or rename tracking, so a rename is genuinely indistinguishable from dropping one column and adding another. The heuristics that could guess (matching position and type, no intervening DML) can still be wrong, and the 2026-08-03 decision (#320) was not to build one. Correct and noisier beats quieter and sometimes wrong.

## The first RelationMessage reports no drift

There is no prior shape to compare against, and treating every column as newly added on first sight would make the first message of **every run** look like a full-table schema change — which under the default `halt` policy would stop every pipeline on startup. Has its own test.

**Continuity across a restart is not solved here.** A fresh process has an empty cache and likewise sees no drift. That is Area 2 step 2 (durable schema history in the position), and it is called out in the code rather than left as an implied gap.

## `IsNarrowing`

Distinguishes add-only from drop/retype, because the `evolve` policy needs it: adding a column is safe to accept automatically since nothing downstream can depend on it yet, while dropping or retyping one can break a consumer that does. This layer reports; judging compatibility is the policy layer's job.

## Stable output

`SchemaDiff.String` sorts its parts. An alert whose wording depends on map iteration order cannot be deduplicated or matched — stability is behaviour, not cosmetics, and has a test.

## Checks

New package lints clean. The 8 integration failures in `source/logrepl/internal` are missing-Postgres (`connection refused` on 5433) — **identical with this change stashed**, verified.

## Next in Area 2

Step 2: durable per-relation schema history in the position (`SchemaHistory`, pruned to the last N versions so positions stay bounded). Step 3: the `halt | dlq | evolve` policy — where `halt` being the default is the **breaking change** that still owes a migration note.