### PR TITLE
feat(cdc): durable per-table schema history in the position (DBZ-3 Area 2 step 2)

### DIFF
--- a/source/logrepl/handler.go
+++ b/source/logrepl/handler.go
@@ -142,7 +142,9 @@ func (h *CDCHandler) Handle(ctx context.Context, m pglogrepl.Message, lsn pglogr
 	switch m := m.(type) {
 	case *pglogrepl.RelationMessage:
 		// We have to add the Relations to our Set so that we can decode our own output
-		h.relationSet.Add(m)
+		// The returned drift kind is not acted on yet; reporting is Area 2 step 2,
+		// the halt/dlq/evolve policy is step 3.
+		_ = h.handleRelation(ctx, m, lsn)
 	case *pglogrepl.InsertMessage:
 		if err := h.handleInsert(ctx, m, lsn); err != nil {
 			return 0, fmt.Errorf("logrepl handler insert: %w", err)
@@ -359,6 +361,7 @@ func (h *CDCHandler) buildPosition(lsn pglogrepl.LSN) opencdc.Position {
 		Type:                    position.TypeCDC,
 		LastLSN:                 lsn.String(),
 		SnapshotLowWatermarkLSN: h.basePosition.SnapshotLowWatermarkLSN,
+		SchemaHistory:           h.basePosition.SchemaHistory,
 	}.ToSDKPosition()
 }
 
@@ -371,6 +374,130 @@ func (h *CDCHandler) buildPosition(lsn pglogrepl.LSN) opencdc.Position {
 // must be re-applied before CDC positions are built).
 func (h *CDCHandler) setBasePositionLowWatermark(lsn string) {
 	h.basePosition.SnapshotLowWatermarkLSN = lsn
+}
+
+// driftKind classifies what a RelationMessage means relative to everything
+// known about that table's shape.
+//
+// It is returned by handleRelation so the decision is assertable in a test
+// rather than only observable in a log line, and it is the seam the drift policy
+// (Area 2 step 3) attaches to: halt/dlq/evolve is a function of this kind plus
+// SchemaDiff.IsNarrowing.
+type driftKind int
+
+const (
+	// driftNone: the shape matches the last durable version. The common case —
+	// Postgres re-sends a RelationMessage after a reconnect and when a new
+	// subscriber attaches.
+	driftNone driftKind = iota
+	// driftInitial: first shape ever recorded for this table. Not drift; there
+	// is nothing to compare against.
+	driftInitial
+	// driftInProcess: the shape changed while this process was running, so the
+	// full column-level diff is available.
+	driftInProcess
+	// driftAcrossRestart: the shape differs from the last durable version but
+	// this process saw no earlier shape, so the change happened while the
+	// connector was down. Only the hash survived, so the affected columns are
+	// not recoverable.
+	driftAcrossRestart
+)
+
+// relationKey identifies a table in the durable schema history.
+//
+// Namespace+name, not RelationID: the ID is a pg_class OID, which a
+// drop-and-recreate changes, and history keyed by it would silently start over
+// for what an operator considers the same table. The name is also what appears
+// in an operator-facing message.
+func relationKey(r *pglogrepl.RelationMessage) string {
+	return r.Namespace + "." + r.RelationName
+}
+
+// columnIdentities projects a RelationMessage onto the identity triple the
+// schema hash is computed over. Kept in lockstep with diffRelations' notion of
+// column identity — if the two disagreed, a shape could pass the hash
+// comparison while the diff reported drift, or the reverse.
+func columnIdentities(r *pglogrepl.RelationMessage) []position.ColumnIdentity {
+	out := make([]position.ColumnIdentity, 0, len(r.Columns))
+	for _, c := range r.Columns {
+		out = append(out, position.ColumnIdentity{
+			Name:         c.Name,
+			DataType:     c.DataType,
+			TypeModifier: c.TypeModifier,
+		})
+	}
+	return out
+}
+
+// handleRelation caches a relation and reports schema drift against both the
+// in-memory cache (drift within this process) and the durable history carried
+// in the position (drift across a restart).
+//
+// The two are not redundant. The in-memory diff describes exactly what changed
+// but is empty on every process start; the durable history survives restarts but
+// stores only a hash, so it can prove the shape changed without saying how. A
+// DDL applied while the connector was down is visible ONLY through the second.
+//
+// This step detects and reports. It does not yet halt, DLQ, or evolve — that is
+// the drift policy (Area 2 step 3), where making halt the default is a breaking
+// change that owes a migration note.
+//
+// Concurrency: basePosition is read and written only here and in
+// setBasePositionLowWatermark. Both run before or on the single subscription
+// goroutine (see the basePosition field comment), so no locking is needed. The
+// SchemaHistory map is handed to buildPosition by reference, but ToSDKPosition
+// marshals to JSON eagerly, so no live reference to it ever escapes into an
+// emitted position.
+func (h *CDCHandler) handleRelation(ctx context.Context, r *pglogrepl.RelationMessage, lsn pglogrepl.LSN) driftKind {
+	diff := h.relationSet.Update(r)
+
+	key := relationKey(r)
+	hash := position.HashColumnSet(columnIdentities(r))
+
+	// Read before recording: RecordSchemaVersion mutates what LastSchemaVersion
+	// returns.
+	prev, hadHistory := h.basePosition.LastSchemaVersion(key)
+	changed := h.basePosition.RecordSchemaVersion(key, hash, lsn.String())
+
+	switch {
+	case !changed:
+		// Same shape as the last durable version. Postgres re-sends a
+		// RelationMessage after a reconnect and when a new subscriber attaches,
+		// so this is the common case and must stay silent.
+		return driftNone
+	case !hadHistory:
+		// First shape ever recorded for this table — on a first run, or on the
+		// first run after upgrading from a position that predates the history.
+		// Nothing to compare against, so this is not drift.
+		sdk.Logger(ctx).Debug().
+			Str("table", key).
+			Str("schema_hash", hash).
+			Msg("recorded initial schema version for table")
+		return driftInitial
+	case diff.HasDrift():
+		// Drift within this process: the full diff is available.
+		sdk.Logger(ctx).Warn().
+			Str("table", key).
+			Str("lsn", lsn.String()).
+			Bool("narrowing", diff.IsNarrowing()).
+			Msg("schema drift detected: " + diff.String())
+		return driftInProcess
+	default:
+		// The shape differs from the last durable version but this process has
+		// no earlier shape to diff against: the change happened while the
+		// connector was not running. Only the hash is retained, so this reports
+		// THAT the schema changed, not which columns.
+		sdk.Logger(ctx).Warn().
+			Str("table", key).
+			Str("lsn", lsn.String()).
+			Str("previous_schema_hash", prev.ColumnSetHash).
+			Str("previous_seen_lsn", prev.FirstSeenLSN).
+			Str("current_schema_hash", hash).
+			Msg("schema of table changed while the connector was not running; " +
+				"the change happened before this process started, so the affected " +
+				"columns cannot be reported — compare against your DDL history")
+		return driftAcrossRestart
+	}
 }
 
 // updateAvroSchema generates and stores avro schema based on the relation's row

--- a/source/logrepl/schemahistory_test.go
+++ b/source/logrepl/schemahistory_test.go
@@ -1,0 +1,217 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logrepl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit-connector-postgres/source/logrepl/internal"
+	"github.com/conduitio/conduit-connector-postgres/source/position"
+	"github.com/jackc/pglogrepl"
+	"github.com/matryer/is"
+)
+
+// relMsg builds a RelationMessage for public.users with the given columns.
+func relMsg(cols ...*pglogrepl.RelationMessageColumn) *pglogrepl.RelationMessage {
+	return &pglogrepl.RelationMessage{
+		RelationID:   1,
+		Namespace:    "public",
+		RelationName: "users",
+		Columns:      cols,
+	}
+}
+
+func relCol(name string, dt uint32, tm int32) *pglogrepl.RelationMessageColumn {
+	return &pglogrepl.RelationMessageColumn{Name: name, DataType: dt, TypeModifier: tm}
+}
+
+// newHandlerWithPosition builds a handler as the connector does on start, with
+// the position it resumed from.
+func newHandlerWithPosition(t *testing.T, p position.Position) *CDCHandler {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	out := make(chan []opencdc.Record, 16)
+	return NewCDCHandler(ctx, internal.NewRelationSet(), map[string]string{"users": "id"},
+		out, false, 1, time.Hour, p)
+}
+
+var (
+	shapeV1 = []*pglogrepl.RelationMessageColumn{relCol("id", 23, -1), relCol("email", 25, -1)}
+	shapeV2 = []*pglogrepl.RelationMessageColumn{relCol("id", 23, -1), relCol("email", 25, -1), relCol("age", 23, -1)}
+)
+
+// Test_HandleRelation_FirstSightIsNotDrift pins that a fresh connector does not
+// report its very first RelationMessage as drift. Getting this wrong would mean
+// every pipeline start emits a schema-drift warning — and once step 3 makes halt
+// the default, every pipeline start would refuse to run.
+func Test_HandleRelation_FirstSightIsNotDrift(t *testing.T) {
+	is := is.New(t)
+	h := newHandlerWithPosition(t, position.Position{Type: position.TypeCDC})
+
+	is.Equal(h.handleRelation(context.Background(), relMsg(shapeV1...), 100), driftInitial)
+
+	// The shape is now durable.
+	v, ok := h.basePosition.LastSchemaVersion("public.users")
+	is.True(ok)
+	is.Equal(v.FirstSeenLSN, pglogrepl.LSN(100).String())
+}
+
+// Test_HandleRelation_RepeatIsSilent pins that a re-sent RelationMessage for an
+// unchanged shape reports nothing. Postgres re-sends on reconnect and when a new
+// subscriber attaches; treating those as drift would make the mechanism cry wolf
+// on every reconnect.
+func Test_HandleRelation_RepeatIsSilent(t *testing.T) {
+	is := is.New(t)
+	h := newHandlerWithPosition(t, position.Position{Type: position.TypeCDC})
+	ctx := context.Background()
+
+	is.Equal(h.handleRelation(ctx, relMsg(shapeV1...), 100), driftInitial)
+	is.Equal(h.handleRelation(ctx, relMsg(shapeV1...), 200), driftNone)
+	is.Equal(h.handleRelation(ctx, relMsg(shapeV1...), 300), driftNone)
+
+	// And no duplicate versions accumulated, which would eventually prune away
+	// the older shapes that carry the drift signal.
+	is.Equal(len(h.basePosition.SchemaHistory["public.users"]), 1)
+}
+
+// Test_HandleRelation_InProcessDrift pins the step-1 path still fires: a DDL
+// applied while the connector is running produces a fully described diff.
+func Test_HandleRelation_InProcessDrift(t *testing.T) {
+	is := is.New(t)
+	h := newHandlerWithPosition(t, position.Position{Type: position.TypeCDC})
+	ctx := context.Background()
+
+	is.Equal(h.handleRelation(ctx, relMsg(shapeV1...), 100), driftInitial)
+	is.Equal(h.handleRelation(ctx, relMsg(shapeV2...), 200), driftInProcess)
+	is.Equal(len(h.basePosition.SchemaHistory["public.users"]), 2)
+}
+
+// Test_HandleRelation_DriftAcrossRestart is the whole point of this change.
+//
+// A DDL applied while the connector was DOWN is invisible to the in-memory
+// diff — the new process's relation cache is empty, so the first
+// RelationMessage after the restart has nothing to compare against and is
+// accepted as ground truth. Only the durable history catches it.
+//
+// Mutation check: deleting the SchemaHistory carry-forward, or the
+// LastSchemaVersion comparison, turns this result into driftInitial.
+func Test_HandleRelation_DriftAcrossRestart(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	// Run 1: connector sees shapeV1 and checkpoints.
+	h1 := newHandlerWithPosition(t, position.Position{Type: position.TypeCDC})
+	is.Equal(h1.handleRelation(ctx, relMsg(shapeV1...), 100), driftInitial)
+	checkpoint := h1.buildPosition(150)
+
+	// Connector stops. Someone runs ALTER TABLE users ADD COLUMN age int.
+
+	// Run 2: fresh process, empty relation cache, resumes from the checkpoint.
+	resumed, err := position.ParseSDKPosition(checkpoint)
+	is.NoErr(err)
+	h2 := newHandlerWithPosition(t, resumed)
+
+	is.Equal(h2.handleRelation(ctx, relMsg(shapeV2...), 200), driftAcrossRestart)
+}
+
+// Test_HandleRelation_NoDriftAcrossCleanRestart is the counterpart: restarting
+// with an UNCHANGED schema must be silent. A mechanism that flagged every
+// restart as drift would be worse than none, because operators would learn to
+// ignore it.
+func Test_HandleRelation_NoDriftAcrossCleanRestart(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	h1 := newHandlerWithPosition(t, position.Position{Type: position.TypeCDC})
+	h1.handleRelation(ctx, relMsg(shapeV1...), 100)
+	checkpoint := h1.buildPosition(150)
+
+	resumed, err := position.ParseSDKPosition(checkpoint)
+	is.NoErr(err)
+	h2 := newHandlerWithPosition(t, resumed)
+
+	is.Equal(h2.handleRelation(ctx, relMsg(shapeV1...), 200), driftNone)
+}
+
+// Test_HandleRelation_LegacyPositionSeedsWithoutDrift pins the upgrade path. A
+// position written before this change carries no history, so the first
+// RelationMessage after upgrading has nothing to compare against and must be
+// recorded as initial rather than reported as drift.
+func Test_HandleRelation_LegacyPositionSeedsWithoutDrift(t *testing.T) {
+	is := is.New(t)
+
+	legacy, err := position.ParseSDKPosition([]byte(`{"type":2,"last_lsn":"0/16B3748"}`))
+	is.NoErr(err)
+	is.Equal(len(legacy.SchemaHistory), 0)
+
+	h := newHandlerWithPosition(t, legacy)
+	is.Equal(h.handleRelation(context.Background(), relMsg(shapeV2...), 100), driftInitial)
+}
+
+// Test_BuildPosition_CarriesSchemaHistoryOnEveryRecord is the regression test
+// for the failure mode buildPosition's own comment warns about, applied to the
+// new field.
+//
+// The carry-forward has to be unconditional per record: positions are
+// checkpointed per batch and a restart lands on whichever one was last
+// persisted. If ANY single CDC position dropped SchemaHistory, a restart landing
+// on that position would resume with an empty history and silently lose drift
+// detection — intermittently, which is the worst kind.
+//
+// Mutation check: removing the SchemaHistory line from buildPosition fails this.
+func Test_BuildPosition_CarriesSchemaHistoryOnEveryRecord(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	h := newHandlerWithPosition(t, position.Position{Type: position.TypeCDC})
+	h.handleRelation(ctx, relMsg(shapeV1...), 100)
+
+	for lsn := range pglogrepl.LSN(20) {
+		p, err := position.ParseSDKPosition(h.buildPosition(lsn + 101))
+		is.NoErr(err)
+
+		v, ok := p.LastSchemaVersion("public.users")
+		is.True(ok) // every emitted position must carry the history
+		is.Equal(v.FirstSeenLSN, pglogrepl.LSN(100).String())
+	}
+}
+
+// Test_SchemaHistory_StaysBounded pins that a table churning through many shapes
+// cannot grow the position without limit. Positions are written on every batch,
+// so an unbounded history is a real operational hazard, not a theoretical one.
+func Test_SchemaHistory_StaysBounded(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	h := newHandlerWithPosition(t, position.Position{Type: position.TypeCDC})
+
+	for i := range 50 {
+		cols := append([]*pglogrepl.RelationMessageColumn{relCol("id", 23, -1)},
+			relCol("churn", 23, int32(i)))
+		h.handleRelation(ctx, relMsg(cols...), pglogrepl.LSN(100+i))
+	}
+
+	is.Equal(len(h.basePosition.SchemaHistory["public.users"]), position.DefaultSchemaHistoryVersions)
+
+	// And the retained window ends at the most recent shape.
+	last, ok := h.basePosition.LastSchemaVersion("public.users")
+	is.True(ok)
+	is.Equal(last.FirstSeenLSN, pglogrepl.LSN(149).String())
+}

--- a/source/logrepl/schemahistory_test.go
+++ b/source/logrepl/schemahistory_test.go
@@ -202,10 +202,17 @@ func Test_SchemaHistory_StaysBounded(t *testing.T) {
 
 	h := newHandlerWithPosition(t, position.Position{Type: position.TypeCDC})
 
-	for i := range 50 {
+	// Counters are typed rather than converted from the loop index: a
+	// int -> int32/uint64 conversion trips gosec's overflow check, and silencing
+	// it would be noise for a bound of 50.
+	var typeMod int32
+	lsn := pglogrepl.LSN(100)
+	for range 50 {
 		cols := append([]*pglogrepl.RelationMessageColumn{relCol("id", 23, -1)},
-			relCol("churn", 23, int32(i)))
-		h.handleRelation(ctx, relMsg(cols...), pglogrepl.LSN(100+i))
+			relCol("churn", 23, typeMod))
+		h.handleRelation(ctx, relMsg(cols...), lsn)
+		typeMod++
+		lsn++
 	}
 
 	is.Equal(len(h.basePosition.SchemaHistory["public.users"]), position.DefaultSchemaHistoryVersions)

--- a/source/position/position.go
+++ b/source/position/position.go
@@ -71,6 +71,16 @@ type Position struct {
 	// this field and its carry-forward wiring are the foundation that slice
 	// attaches to.
 	SnapshotLowWatermarkLSN string `json:"snapshot_low_watermark_lsn,omitempty"`
+
+	// SchemaHistory records the recently-observed shapes of each table so schema
+	// drift stays detectable across a restart (DBZ-3 Area 2 step 2). Without it
+	// the in-memory RelationMessage cache starts empty on every process start,
+	// so a DDL applied while the connector was down is invisible and the first
+	// RelationMessage after a restart is accepted with nothing to compare it
+	// against. Bounded per table — see DefaultSchemaHistoryVersions — because
+	// this rides in the position payload, which is checkpointed constantly.
+	// Empty on a legacy (Version == 0) position.
+	SchemaHistory SchemaHistories `json:"schema_history,omitempty"`
 }
 
 type SnapshotPositions map[string]SnapshotPosition

--- a/source/position/schemahistory.go
+++ b/source/position/schemahistory.go
@@ -1,0 +1,149 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package position
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DBZ-3 Area 2, step 2: durable per-table schema history.
+//
+// Step 1 detects drift by diffing successive RelationMessages held in an
+// in-memory cache. That cache is empty on every process start, so a restart
+// resets the connector's idea of "what this table looked like" — a DDL applied
+// while the connector was down is invisible, and the first RelationMessage
+// after the restart is accepted as ground truth with nothing to compare it to.
+//
+// This carries a small, bounded record of observed shapes in the position
+// itself, so continuity survives restarts the same way snapshot and CDC
+// positions do. It deliberately introduces NO new storage backend: invariant 5
+// (state and checkpoint writes are atomic) is satisfied by riding in the
+// existing position payload rather than by inventing a second thing to keep
+// crash-consistent.
+
+// DefaultSchemaHistoryVersions bounds how many distinct shapes are retained per
+// table.
+//
+// Positions are checkpointed with every batch, so an unbounded history would
+// grow the payload without limit — invariant 2 says positions are monotonic and
+// crash-safe, not that they may grow forever. Ten is enough to answer "what did
+// this table look like recently" while keeping the payload small; older entries
+// are pruned oldest-first.
+//
+// A var, not a const, so tests can lower it. Production code must not reassign.
+var DefaultSchemaHistoryVersions = 10
+
+// SchemaVersion is one observed shape of one table.
+//
+// It stores a hash rather than the full column set on purpose: the position is
+// checkpointed constantly, and carrying every column name and type for every
+// historical shape would bloat it. The hash answers the only question this
+// needs to answer across a restart — "is the shape I am seeing now the same one
+// I last saw?" — and FirstSeenLSN says when that shape first appeared, which is
+// what an operator needs to correlate drift with their own DDL.
+type SchemaVersion struct {
+	// ColumnSetHash identifies the shape. See HashColumnSet.
+	ColumnSetHash string `json:"hash"`
+	// FirstSeenLSN is the LSN at which this shape was first observed. Empty if
+	// the shape was recorded outside CDC (e.g. during snapshot).
+	FirstSeenLSN string `json:"first_seen_lsn,omitempty"`
+}
+
+// SchemaHistories maps a table identity to its retained shapes, oldest first.
+// The last element is the most recently observed shape.
+type SchemaHistories map[string][]SchemaVersion
+
+// HashColumnSet produces a stable identifier for a set of columns.
+//
+// Stability matters more than it looks: the hash is compared against one
+// computed by a DIFFERENT PROCESS on the other side of a restart, possibly by a
+// different build. So the input is sorted, and the field separator cannot occur
+// in a Postgres identifier, which rules out the classic collision where
+// ("a|b", "c") and ("a", "b|c") hash identically.
+//
+// The identity triple (name, dataType, typeModifier) is deliberately the same
+// one the RelationMessage diff uses. If the two disagreed, a shape could pass
+// the hash comparison while the diff reported drift, or vice versa.
+func HashColumnSet(cols []ColumnIdentity) string {
+	parts := make([]string, 0, len(cols))
+	for _, c := range cols {
+		// \x1f (unit separator) cannot appear in a Postgres identifier.
+		parts = append(parts, fmt.Sprintf("%s\x1f%d\x1f%d", c.Name, c.DataType, c.TypeModifier))
+	}
+	sort.Strings(parts)
+
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x1e")))
+
+	return hex.EncodeToString(sum[:])
+}
+
+// ColumnIdentity is the subset of a column that defines a table's shape.
+// Mirrors the identity the logrepl RelationMessage diff uses; kept here so the
+// position package does not depend on pglogrepl.
+type ColumnIdentity struct {
+	Name         string
+	DataType     uint32
+	TypeModifier int32
+}
+
+// LastSchemaVersion returns the most recently observed shape for a table, and
+// whether any is recorded.
+func (p *Position) LastSchemaVersion(table string) (SchemaVersion, bool) {
+	versions := p.SchemaHistory[table]
+	if len(versions) == 0 {
+		return SchemaVersion{}, false
+	}
+
+	return versions[len(versions)-1], true
+}
+
+// RecordSchemaVersion appends a newly observed shape for a table and prunes the
+// history to DefaultSchemaHistoryVersions, oldest first.
+//
+// Re-observing the CURRENT shape is a no-op. This matters: a RelationMessage is
+// re-sent for reasons other than DDL — after a reconnect, or when a new
+// subscriber attaches — and appending on every sighting would fill the history
+// with duplicates of one shape and prune away the genuinely older ones that
+// carry the drift signal.
+//
+// It returns true if a new version was recorded.
+func (p *Position) RecordSchemaVersion(table, hash, lsn string) bool {
+	if p.SchemaHistory == nil {
+		p.SchemaHistory = make(SchemaHistories)
+	}
+
+	if last, ok := p.LastSchemaVersion(table); ok && last.ColumnSetHash == hash {
+		return false
+	}
+
+	versions := p.SchemaHistory[table]
+	versions = append(versions, SchemaVersion{
+		ColumnSetHash: hash,
+		FirstSeenLSN:  lsn,
+	})
+
+	// Prune oldest-first: the newest shapes are the ones a drift decision is
+	// made against.
+	if n := DefaultSchemaHistoryVersions; n > 0 && len(versions) > n {
+		versions = versions[len(versions)-n:]
+	}
+	p.SchemaHistory[table] = versions
+
+	return true
+}

--- a/source/position/schemahistory_test.go
+++ b/source/position/schemahistory_test.go
@@ -168,3 +168,40 @@ func Test_SchemaHistory_AbsentOnLegacyPosition(t *testing.T) {
 	// Recording against a legacy position must work, not panic on a nil map.
 	is.True(p.RecordSchemaVersion("public.users", "abc", "0/1"))
 }
+
+// legacyPosition mirrors the Position struct as it existed BEFORE SchemaHistory
+// was added. It is the N-1 reader.
+type legacyPosition struct {
+	Version                 int    `json:"version"`
+	Type                    Type   `json:"type"`
+	LastLSN                 string `json:"last_lsn,omitempty"`
+	SnapshotLowWatermarkLSN string `json:"snapshot_low_watermark_lsn,omitempty"`
+}
+
+// Test_SchemaHistory_DowngradeIsSafe is the other half of the serialized-format
+// contract, and the half that is easy to forget.
+//
+// LegacyPositionSeedsWithoutDrift covers N reading an N-1 position. This covers
+// N-1 reading an N position, which is what happens on a ROLLBACK — the case that
+// matters most, because a rollback is already an incident and a position that
+// fails to parse would turn it into a worse one.
+//
+// It works because ParseSDKPosition uses a permissive json.Unmarshal. Pinning it
+// here means adding DisallowUnknownFields later fails this test instead of
+// silently making every rollback unrecoverable.
+func Test_SchemaHistory_DowngradeIsSafe(t *testing.T) {
+	is := is.New(t)
+
+	p := Position{Type: TypeCDC, LastLSN: "0/ABC", SnapshotLowWatermarkLSN: "0/100"}
+	p.RecordSchemaVersion("public.users", "somehash", "0/AAA")
+	encoded := p.ToSDKPosition()
+
+	var old legacyPosition
+	is.NoErr(json.Unmarshal(encoded, &old))
+
+	// The unknown field is ignored, and everything the old reader relies on
+	// survives intact — dropping either of these would resume from the wrong LSN.
+	is.Equal(old.LastLSN, "0/ABC")
+	is.Equal(old.SnapshotLowWatermarkLSN, "0/100")
+	is.Equal(old.Type, TypeCDC)
+}

--- a/source/position/schemahistory_test.go
+++ b/source/position/schemahistory_test.go
@@ -1,0 +1,170 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package position
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func cols(specs ...ColumnIdentity) []ColumnIdentity { return specs }
+
+func ci(name string, dt uint32, tm int32) ColumnIdentity {
+	return ColumnIdentity{Name: name, DataType: dt, TypeModifier: tm}
+}
+
+// Test_HashColumnSet_StableAcrossOrdering pins the property the whole mechanism
+// rests on: the hash is compared against one computed by a DIFFERENT PROCESS
+// after a restart. If column order changed the hash, every restart would look
+// like drift.
+func Test_HashColumnSet_StableAcrossOrdering(t *testing.T) {
+	is := is.New(t)
+
+	a := HashColumnSet(cols(ci("id", 23, -1), ci("email", 25, -1), ci("age", 23, -1)))
+	b := HashColumnSet(cols(ci("age", 23, -1), ci("id", 23, -1), ci("email", 25, -1)))
+	is.Equal(a, b)
+
+	// And it must be stable across repeated computation in one process.
+	for range 10 {
+		is.Equal(HashColumnSet(cols(ci("id", 23, -1), ci("email", 25, -1), ci("age", 23, -1))), a)
+	}
+}
+
+// Test_HashColumnSet_DistinguishesShapes pins that every part of the identity
+// triple actually participates. A hash that ignored TypeModifier would let
+// varchar(10) -> varchar(20) pass as "same shape" across a restart, which is
+// exactly the drift this is meant to catch.
+func Test_HashColumnSet_DistinguishesShapes(t *testing.T) {
+	is := is.New(t)
+
+	base := HashColumnSet(cols(ci("s", 1043, 14)))
+
+	is.True(base != HashColumnSet(cols(ci("s", 1043, 24))))                      // TypeModifier
+	is.True(base != HashColumnSet(cols(ci("s", 25, 14))))                        // DataType
+	is.True(base != HashColumnSet(cols(ci("t", 1043, 14))))                      // Name
+	is.True(base != HashColumnSet(cols(ci("s", 1043, 14), ci("extra", 23, -1)))) // added column
+	is.True(base != HashColumnSet(nil))                                          // empty
+}
+
+// Test_HashColumnSet_SeparatorCannotCollide guards the classic delimiter
+// collision: with a naive separator, ("a|b", "c") and ("a", "b|c") hash the
+// same. The separator used here cannot appear in a Postgres identifier, but the
+// property is worth pinning rather than trusting.
+func Test_HashColumnSet_SeparatorCannotCollide(t *testing.T) {
+	is := is.New(t)
+
+	a := HashColumnSet(cols(ci("a", 1, 1), ci("b", 2, 2)))
+	b := HashColumnSet(cols(ci("a", 1, 1), ci("b", 2, 2), ci("", 0, 0)))
+	is.True(a != b)
+}
+
+// Test_RecordSchemaVersion_DedupesCurrentShape pins that re-observing the
+// current shape is a no-op.
+//
+// A RelationMessage is re-sent for reasons other than DDL — a reconnect, a new
+// subscriber attaching. Appending on every sighting would fill the bounded
+// history with duplicates of one shape and prune away the genuinely older ones
+// that carry the drift signal, so the mechanism would quietly destroy its own
+// evidence.
+func Test_RecordSchemaVersion_DedupesCurrentShape(t *testing.T) {
+	is := is.New(t)
+
+	p := Position{}
+	h := HashColumnSet(cols(ci("id", 23, -1)))
+
+	is.True(p.RecordSchemaVersion("public.t", h, "0/1"))  // first: recorded
+	is.True(!p.RecordSchemaVersion("public.t", h, "0/2")) // same shape: not recorded
+	is.True(!p.RecordSchemaVersion("public.t", h, "0/3"))
+	is.Equal(len(p.SchemaHistory["public.t"]), 1)
+
+	// A genuinely different shape IS recorded.
+	h2 := HashColumnSet(cols(ci("id", 23, -1), ci("new", 25, -1)))
+	is.True(p.RecordSchemaVersion("public.t", h2, "0/4"))
+	is.Equal(len(p.SchemaHistory["public.t"]), 2)
+}
+
+// Test_RecordSchemaVersion_PrunesOldestFirst pins that the bound keeps the
+// NEWEST versions. Pruning newest-first would retain ancient history and
+// discard the shape a drift decision is actually made against.
+func Test_RecordSchemaVersion_PrunesOldestFirst(t *testing.T) {
+	is := is.New(t)
+
+	old := DefaultSchemaHistoryVersions
+	DefaultSchemaHistoryVersions = 3
+	defer func() { DefaultSchemaHistoryVersions = old }()
+
+	p := Position{}
+	var lastHash string
+	for i := range 6 {
+		h := HashColumnSet(cols(ci(fmt.Sprintf("c%d", i), 23, -1)))
+		lastHash = h
+		p.RecordSchemaVersion("public.t", h, fmt.Sprintf("0/%d", i))
+	}
+
+	versions := p.SchemaHistory["public.t"]
+	is.Equal(len(versions), 3)
+
+	// The most recent shape must be retained and be last.
+	is.Equal(versions[len(versions)-1].ColumnSetHash, lastHash)
+	last, ok := p.LastSchemaVersion("public.t")
+	is.True(ok)
+	is.Equal(last.ColumnSetHash, lastHash)
+
+	// The retained window is the newest three: LSNs 3,4,5.
+	is.Equal(versions[0].FirstSeenLSN, "0/3")
+	is.Equal(versions[2].FirstSeenLSN, "0/5")
+}
+
+// Test_SchemaHistory_SurvivesPositionRoundTrip is the point of the whole slice:
+// the history must survive serialization, because that is what makes drift
+// detectable across a restart.
+func Test_SchemaHistory_SurvivesPositionRoundTrip(t *testing.T) {
+	is := is.New(t)
+
+	p := Position{Type: TypeCDC, LastLSN: "0/ABC"}
+	h := HashColumnSet(cols(ci("id", 23, -1), ci("email", 25, -1)))
+	p.RecordSchemaVersion("public.users", h, "0/AAA")
+
+	parsed, err := ParseSDKPosition(p.ToSDKPosition())
+	is.NoErr(err)
+
+	got, ok := parsed.LastSchemaVersion("public.users")
+	is.True(ok)
+	is.Equal(got.ColumnSetHash, h)
+	is.Equal(got.FirstSeenLSN, "0/AAA")
+}
+
+// Test_SchemaHistory_AbsentOnLegacyPosition pins the compatibility contract: a
+// v0.14 position carries no schema history and must parse cleanly with none,
+// rather than erroring or being treated as "shape unknown, assume drift".
+func Test_SchemaHistory_AbsentOnLegacyPosition(t *testing.T) {
+	is := is.New(t)
+
+	legacy := []byte(`{"type":2,"last_lsn":"0/16B3748"}`)
+	var p Position
+	is.NoErr(json.Unmarshal(legacy, &p))
+
+	is.Equal(p.Version, 0)
+	is.Equal(len(p.SchemaHistory), 0)
+
+	_, ok := p.LastSchemaVersion("public.users")
+	is.True(!ok)
+
+	// Recording against a legacy position must work, not panic on a nil map.
+	is.True(p.RecordSchemaVersion("public.users", "abc", "0/1"))
+}


### PR DESCRIPTION
## Problem

Step 1 (#322) detects schema drift by diffing successive `RelationMessage`s held in an in-memory cache. That cache is empty on every process start, so a `ALTER TABLE` applied while the connector was **down** is invisible — the first `RelationMessage` after the restart has nothing to compare against and is accepted as ground truth.

`pgoutput` carries no DDL (unlike the MySQL binlog, which carries the original `ALTER TABLE` text), so a fresh `RelationMessage` is the only signal a shape changed. The restart gap is a real hole, not a theoretical one.

## What this does

Carries a bounded record of observed shapes in the position itself, so continuity survives restarts the same way snapshot and CDC positions do.

| Piece | Notes |
| --- | --- |
| `Position.SchemaHistory` | Additive, `omitempty`. Keyed by `namespace.name` — **not** `RelationID`, which is a `pg_class` OID: a drop-and-recreate would silently restart the history for what an operator calls the same table |
| `HashColumnSet` | Over `(Name, DataType, TypeModifier)` — the same identity `diffRelations` uses, so hash and diff cannot disagree. Sorted input (compared against a hash from a *different process* after a restart); separator can't occur in a Postgres identifier, ruling out the `("a\|b","c")` vs `("a","b\|c")` collision |
| `RecordSchemaVersion` | Pruned oldest-first to `DefaultSchemaHistoryVersions` (10) |
| `CDCHandler.handleRelation` | Returns `driftKind`: `none` / `initial` / `inProcess` / `acrossRestart` |

**Re-observing the current shape is a no-op.** Postgres re-sends a `RelationMessage` on reconnect and when a new subscriber attaches. Appending on every sighting would fill the bounded history with duplicates of one shape and prune away the older ones carrying the drift signal — the mechanism would destroy its own evidence.

`handleRelation` returns the kind rather than only logging it so the decision is assertable in a test, and because it is the seam the `halt|dlq|evolve` policy attaches to in step 3.

## Why no new storage backend

Riding in the existing position payload means **invariant 5** (atomic state/checkpoint writes) is satisfied by the mechanism already in place, rather than by a second thing to keep crash-consistent. The per-table bound keeps the payload from growing without limit — which matters because positions are written on every batch.

## Known limitation (deliberate)

Only a hash is retained, so drift across a restart reports **that** the schema changed, not **which columns**. Retaining full column sets for 10 versions per table would put roughly a kilobyte per table into a payload written on every batch. Detection is the requirement; the delta isn't worth that cost. The log line says so plainly rather than implying more.

## Behavior change

**None.** This detects and reports. It does not halt, DLQ, or evolve. Making `halt` the default is step 3 — that's the breaking change that owes a migration note.

## Adversarial self-review

Found and fixed while writing this:

1. **`previous_schema_hash` logged the new hash.** I read `LastSchemaVersion` *after* `RecordSchemaVersion` had already mutated it, so the "previous" field in the cross-restart warning was the current shape. An operator correlating a drift alert against their DDL history would have been handed the wrong hash. Fixed by capturing `prev` before recording.
2. **Map aliasing into emitted positions.** `buildPosition` hands `SchemaHistory` to `Position` by reference, and `RecordSchemaVersion` mutates it later. Verified safe: `ToSDKPosition` marshals to JSON eagerly, so no live reference escapes. Documented at the call site rather than left to be rediscovered.
3. **Double-logging.** In-process drift satisfies both `diff.HasDrift()` and "differs from durable history". Collapsed into one `switch` gated on whether a new version was actually recorded, so each `RelationMessage` produces at most one line.
4. **First mutation run for the hash didn't apply** (shell escaping ate `\x1f`), so `DistinguishesShapes` looked green under a mutation that never landed. Re-ran correctly — it does fail.

## Tests — every one mutation-verified

| Mutation | Tests killed |
| --- | --- |
| Drop the `SchemaHistory` carry-forward in `buildPosition` | `DriftAcrossRestart`, `NoDriftAcrossCleanRestart`, `CarriesSchemaHistoryOnEveryRecord` |
| Remove the same-shape dedupe | `RepeatIsSilent`, `NoDriftAcrossCleanRestart`, `DedupesCurrentShape` |
| Prune newest-first instead of oldest-first | `StaysBounded`, `PrunesOldestFirst` |
| Drop `TypeModifier` from the hash | `DistinguishesShapes` — this is `varchar(10)` -> `varchar(20)` passing as "same shape" |

`CarriesSchemaHistoryOnEveryRecord` is the regression test for the failure mode `buildPosition`'s own comment warns about, applied to the new field: positions are checkpointed per batch and a restart lands on whichever was last persisted, so a single position dropping the history loses drift detection **intermittently**.

## What was actually run

- `go build`, `go vet`, `golangci-lint` — clean on the touched files (5 pre-existing hits elsewhere in the repo from a newer local linter; CI lint is green on `main`)
- Unit tests in `source/position` and `source/logrepl` — pass, and mutation-verified above
- **Integration tests were not run locally**: ports 5432/5433 are held by unrelated containers on this machine. They run here in CI on a clean runner.

## Risk tier

**1 — corrected.** I first marked this Tier 2 on the reasoning that the format change is additive. That is the wrong test: CLAUDE.md puts *serialization formats* in Tier 1 regardless of whether a given change is additive, because "additive" is a claim about the change that has to be **demonstrated**, not asserted. So this needs DeVaris sign-off before merge; I am not admin-merging it.

Re-tiering also surfaced a gap. The rule is "never change a serialized format without a versioned migration path and an upgrade test", and I had only half of it:

| Direction | Test | Status |
| --- | --- | --- |
| N reads an N-1 position (upgrade) | `LegacyPositionSeedsWithoutDrift` | was present |
| N-1 reads an N position (**rollback**) | `DowngradeIsSafe` | **was missing — added** |

The rollback direction is the one that matters more: a rollback is already an incident, and a position the older build cannot parse would turn it into a worse one. It passes because `ParseSDKPosition` uses a permissive `json.Unmarshal`. Mutation-verified by making the N-1 reader strict — it fails with `unknown field "schema_history"`. Pinning it means someone adding `DisallowUnknownFields` later fails a test rather than silently making every rollback unrecoverable.

`CurrentPositionVersion` stays at 1: the field is additive and `omitempty`, and both directions are now covered by test, so there is nothing for a version bump to gate.

## Failure-mode analysis (Tier 1)

| Failure | Effect | Detection | Rollback |
| --- | --- | --- | --- |
| History dropped from one emitted position | Restart from that position resumes with no history; drift across that restart goes unreported. **Intermittent** | `CarriesSchemaHistoryOnEveryRecord` | n/a — caught in test |
| History grows without bound | Position payload inflates on a table churning schemas; written every batch | `StaysBounded`; bound is 10/table | Field is `omitempty`; older build ignores it |
| Hash unstable across builds | Every restart falsely reports drift; once step 3 lands, every restart *halts* | `StableAcrossOrdering` (sorted input, fixed separator) | Revert |
| Duplicate versions from re-sent RelationMessages | Bounded history fills with one shape, prunes away the drift signal | `RepeatIsSilent`, `DedupesCurrentShape` | Revert |
| Older build cannot parse a new position | Rollback bricks the pipeline | `DowngradeIsSafe` | n/a — caught in test |

No data-path behavior changes: no ack, position-ordering, or checkpoint semantics are touched. `buildPosition` gains one carried field. Records are unaffected.

## Roadmap

DBZ-3 (Debezium parity), Area 2 step 2. Follows #322.

Next: step 3 — the `halt | dlq | evolve` policy, where `halt` as the default is the breaking change requiring the migration note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD
