### PR TITLE
feat(chaos): fault-injection seam for the DBZ-3 kill harness (B0-1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,21 @@ jobs:
       - name: Build (conduitchaos)
         run: go build -tags conduitchaos ./...
 
+      # Lints the TAGGED variant. This is a separate invocation, not a
+      # build-tags entry in .golangci.yml, and the difference is load-bearing:
+      # golangci-lint v2 merges config build-tags additively, so putting
+      # conduitchaos in the config makes the DEFAULT `golangci-lint run` — the
+      # one lint.yml and `make lint` already invoke — analyze the tagged
+      # variant and silently stop analyzing the untagged one. Verified
+      # empirically: a deliberate `declared and not used` in the !conduitchaos
+      # file went unreported, while the same bait in the tagged file was
+      # caught. Keeping the config untouched means both variants are linted:
+      # the default job covers the code that ships, this one covers the code
+      # that only the harness builds.
+      - name: Lint (conduitchaos)
+        uses: golangci/golangci-lint-action@v6
+        with:
+          args: --build-tags conduitchaos
+
       - name: Vet (conduitchaos)
         run: go vet -tags conduitchaos ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,21 @@ jobs:
       # caught. Keeping the config untouched means both variants are linted:
       # the default job covers the code that ships, this one covers the code
       # that only the harness builds.
+      # Version comes from tools/go.mod, exactly as lint.yml derives it. Pinning
+      # matters here: golangci-lint-action's default is a v1 release, and this
+      # repo's .golangci.yml is v2 config — an unpinned action fails with
+      # "the configuration contains invalid elements" rather than a lint error,
+      # which reads like a broken config instead of a broken workflow.
+      - name: Resolve golangci-lint version
+        id: golangci-lint-version
+        run: |
+          GOLANGCI_LINT_VERSION=$( go list -modfile=tools/go.mod -m -f '{{.Version}}' github.com/golangci/golangci-lint/v2 )
+          echo "v=${GOLANGCI_LINT_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Lint (conduitchaos)
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
+          version: ${{ steps.golangci-lint-version.outputs.v }}
           args: --build-tags conduitchaos
 
       - name: Vet (conduitchaos)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,27 @@ jobs:
 
       - name: Test
         run: make test GOTEST_FLAGS="-v -count=1"
+
+  # `make test` (the job above) never passes -tags conduitchaos, so it never
+  # compiles internal/chaospoint's real (parking) implementation or, once
+  # B0-2 lands, test/chaos itself. Without this job a rename anywhere the
+  # chaos build reaches (e.g. a call site under source/) would break the
+  # kill harness silently: nothing in CI would notice until someone tried
+  # to run it. No path filter, on every push/PR, same as `test` above — the
+  # repo is small enough that a change detector would only add a
+  # fail-closed surface for no real saving (see the B0 harness plan, §7).
+  chaos-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build (conduitchaos)
+        run: go build -tags conduitchaos ./...
+
+      - name: Vet (conduitchaos)
+        run: go vet -tags conduitchaos ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,4 @@
 version: "2"
-run:
-  # Without this, golangci-lint never sees files gated by the conduitchaos
-  # build tag (internal/chaospoint's real implementation, and later the
-  # DBZ-3 process-kill chaos harness under test/chaos) — they would ship
-  # unlinted forever, silently, because `golangci-lint run` builds with the
-  # default tag set unless told otherwise. `make test` has the same blind
-  # spot for `go vet`/`go build`, which is why CI runs a separate
-  # `-tags conduitchaos` build/vet job rather than relying on lint alone.
-  build-tags:
-    - conduitchaos
 linters:
   default: none
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,14 @@
 version: "2"
+run:
+  # Without this, golangci-lint never sees files gated by the conduitchaos
+  # build tag (internal/chaospoint's real implementation, and later the
+  # DBZ-3 process-kill chaos harness under test/chaos) — they would ship
+  # unlinted forever, silently, because `golangci-lint run` builds with the
+  # default tag set unless told otherwise. `make test` has the same blind
+  # spot for `go vet`/`go build`, which is why CI runs a separate
+  # `-tags conduitchaos` build/vet job rather than relying on lint alone.
+  build-tags:
+    - conduitchaos
 linters:
   default: none
   enable:

--- a/internal/chaospoint/chaospoint.go
+++ b/internal/chaospoint/chaospoint.go
@@ -1,0 +1,28 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !conduitchaos
+
+package chaospoint
+
+// Reach is a no-op in the default (released) build. It exists so production
+// call sites can call chaospoint.Reach(name) unconditionally, without an
+// #ifdef-style branch at each site, while the released binary — built with
+// no -tags by both .goreleaser.yml and .github/workflows/publish.yml —
+// contains no fault-injection behavior at all. The compiler inlines this
+// away; it costs nothing at the call site.
+//
+// The parking implementation lives in chaospoint_on.go, gated by the
+// conduitchaos build tag, and is never linked into a released artifact.
+func Reach(_ string) {}

--- a/internal/chaospoint/chaospoint_on.go
+++ b/internal/chaospoint/chaospoint_on.go
@@ -1,0 +1,139 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build conduitchaos
+
+package chaospoint
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// target is the point/count pair parsed from PGCHAOS_PARK. targetSet is
+// false when PGCHAOS_PARK is unset or empty, in which case Reach never
+// parks — it still counts, so a no-kill smoke run can assert liveness
+// witnesses.
+var (
+	parkConfigOnce sync.Once
+	target         parkTarget
+	targetSet      bool
+)
+
+type parkTarget struct {
+	point string
+	nth   uint64
+}
+
+// loadParkConfig reads PGCHAOS_PARK exactly once — on the first call to
+// Reach in the process — and memoizes it in target/targetSet for every
+// subsequent call. In the harness's real use, that first call happens
+// within milliseconds of the child process starting, before it has done
+// anything observable, so in practice this is indistinguishable from
+// reading it at startup: the park configuration is fixed for the life of
+// the process and cannot be raced or re-targeted mid-run by anything the
+// connector itself does. (A literal package init() would read the
+// environment before any test could ever set it via t.Setenv, which is
+// exactly the property chaospoint_on_test.go exercises directly.)
+//
+// A malformed PGCHAOS_PARK fails loud (stderr + os.Exit) instead of
+// silently never parking: a typo in the harness must surface as an
+// immediate, obvious child failure, not as a mystifying waitForMarker
+// timeout minutes into a CI run.
+func loadParkConfig() {
+	parkConfigOnce.Do(func() {
+		raw, ok := os.LookupEnv("PGCHAOS_PARK")
+		if !ok || raw == "" {
+			return
+		}
+
+		point, nthStr, found := strings.Cut(raw, ":")
+		if !found || point == "" {
+			fmt.Fprintf(os.Stderr, "chaospoint: malformed PGCHAOS_PARK %q, want \"<point>:<nth>\"\n", raw)
+			os.Exit(2)
+		}
+
+		nth, err := strconv.ParseUint(nthStr, 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "chaospoint: malformed PGCHAOS_PARK nth %q: %v\n", nthStr, err)
+			os.Exit(2)
+		}
+
+		target = parkTarget{point: point, nth: nth}
+		targetSet = true
+	})
+}
+
+var (
+	countersMu sync.Mutex
+	counters   = map[string]*uint64{}
+)
+
+// Reach records one visit to the named fault-injection point. When
+// PGCHAOS_PARK targets this point's Nth reach, Reach announces PARKED on
+// stdout as a single write(2) — so the parent's waitForMarker never sees a
+// torn partial line — and then blocks the calling goroutine forever.
+//
+// There is deliberately no way out of the park: the harness's kill signal
+// targets the whole process, not this goroutine, so a context or
+// cancellation path here would only make the suspension less exact.
+//
+// The per-name counter is incremented atomically; concurrent callers (e.g.
+// the replication status ticker running alongside a parked snapshot fetch)
+// cannot corrupt or race each other's counts.
+func Reach(name string) {
+	loadParkConfig()
+
+	n := atomic.AddUint64(counterFor(name), 1)
+
+	if !targetSet || name != target.point || n != target.nth {
+		return
+	}
+
+	msg := fmt.Sprintf("PARKED %s %d\n", name, n)
+	_, _ = os.Stdout.WriteString(msg)
+
+	select {} // park forever; only a signal to the process ends this
+}
+
+func counterFor(name string) *uint64 {
+	countersMu.Lock()
+	defer countersMu.Unlock()
+
+	c, ok := counters[name]
+	if !ok {
+		c = new(uint64)
+		counters[name] = c
+	}
+	return c
+}
+
+// Counts returns a snapshot of the per-point reach counters, keyed by point
+// name. The harness uses it to assert liveness witnesses — e.g. "the point
+// was reached at least 3 times" — rather than trusting a bare pass; a
+// missing witness fails the test as inconclusive instead of green.
+func Counts() map[string]uint64 {
+	countersMu.Lock()
+	defer countersMu.Unlock()
+
+	out := make(map[string]uint64, len(counters))
+	for name, c := range counters {
+		out[name] = atomic.LoadUint64(c)
+	}
+	return out
+}

--- a/internal/chaospoint/chaospoint_on_test.go
+++ b/internal/chaospoint/chaospoint_on_test.go
@@ -1,0 +1,114 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build conduitchaos
+
+package chaospoint
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+// TestReachParks proves the real, conduitchaos-tagged Reach: given a
+// matching PGCHAOS_PARK, it emits the PARKED marker and then never
+// returns.
+//
+// It sets PGCHAOS_PARK via t.Setenv and relies on loadParkConfig's
+// sync.Once firing on Reach's first call within this process — this is
+// the only test in the package that calls Reach, so that first call is
+// this test's. A literal package init() would have read the environment
+// before t.Setenv ever ran, which is exactly why chaospoint_on.go reads it
+// lazily instead (see loadParkConfig's doc).
+//
+// Reach is called on its own goroutine, not this test's main goroutine:
+// select{} inside Reach blocks forever with no timer anywhere that could
+// wake it, and if that goroutine WERE the test's main goroutine, the Go
+// runtime's deadlock detector would (correctly) kill the process with
+// "all goroutines are asleep" the instant it parked, since nothing else
+// in the process would be capable of making progress. Running it on a
+// background goroutine and observing it from the main goroutine via a
+// timer-bounded select avoids that: the main goroutine stays demonstrably
+// "awake" the whole time.
+func TestReachParks(t *testing.T) {
+	is := is.New(t)
+
+	const (
+		point = "chaospoint.unit_test.point"
+		nth   = 1
+	)
+	t.Setenv("PGCHAOS_PARK", fmt.Sprintf("%s:%d", point, nth))
+
+	// Redirect the process's real stdout so the test can observe the exact
+	// bytes Reach writes, the same channel the harness's parent process
+	// reads the PARKED marker from.
+	r, w, err := os.Pipe()
+	is.NoErr(err)
+
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	markerLines := make(chan string, 1)
+	go func() {
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			line := sc.Text()
+			if strings.HasPrefix(line, "PARKED ") {
+				markerLines <- line
+				return
+			}
+		}
+	}()
+
+	returned := make(chan struct{})
+	go func() {
+		Reach(point) // 1st reach == target nth: must park, never return
+		close(returned)
+	}()
+
+	select {
+	case line := <-markerLines:
+		is.Equal(line, fmt.Sprintf("PARKED %s %d", point, nth))
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the PARKED marker on stdout")
+	}
+
+	// The marker is written immediately before Reach enters `select {}`
+	// (chaospoint_on.go) — its presence already proves the goroutine is
+	// past the point of no return. Confirm it, rather than inferring
+	// parking purely from a timeout: `returned` staying open for a bounded
+	// window is direct evidence the goroutine has not come back.
+	select {
+	case <-returned:
+		t.Fatal("Reach returned instead of parking")
+	case <-time.After(300 * time.Millisecond):
+		// still blocked in Reach — expected.
+	}
+
+	is.Equal(Counts()[point], uint64(nth))
+}
+
+// Note: loadParkConfig's sync.Once fires on the first Reach call anywhere
+// in this process (see its doc) and is deliberately not reset between
+// tests — that statelessness is the honest reflection of the real child
+// process, which calls loadParkConfig exactly once, ever. This file
+// therefore keeps a single test that exercises Reach's park behavior, so
+// no later test could observe a stale, already-consumed PGCHAOS_PARK.

--- a/internal/chaospoint/chaospoint_test.go
+++ b/internal/chaospoint/chaospoint_test.go
@@ -1,0 +1,56 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file carries no build tag, so it runs in the default build (the one
+// every release ships) and proves the no-op property directly: Reach must
+// return immediately, every time, regardless of name or of PGCHAOS_PARK
+// being set in the environment. There is no parking implementation to link
+// against here — the assertion is that calling Reach at all is harmless.
+package chaospoint
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+func TestReach_DefaultBuildIsNoOp(t *testing.T) {
+	is := is.New(t)
+
+	// Even a PGCHAOS_PARK that would target a real point under the
+	// conduitchaos build must not matter here: the default build has no
+	// code path that reads it.
+	t.Setenv("PGCHAOS_PARK", SnapshotFetchRow+":1")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 1000; i++ {
+			Reach(SnapshotFetchRow)
+			Reach(PreStartSubscriber)
+			Reach(StandbyStatusUpdate)
+			Reach("")
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reach did not return promptly in the default build — it must be a true no-op")
+	}
+
+	is.True(os.Getenv("PGCHAOS_PARK") != "") // sanity: env var really was set and ignored
+}

--- a/internal/chaospoint/names.go
+++ b/internal/chaospoint/names.go
@@ -1,0 +1,78 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chaospoint provides named fault-injection points for the DBZ-3
+// process-kill chaos harness (test/chaos, ConduitIO/conduit-connector-postgres,
+// see docs/design-documents for the harness design).
+//
+// Production code calls Reach(name) unconditionally at a small number of
+// call sites. In the default build (no build tags) Reach is an empty
+// function the compiler inlines away — this file, names.go, carries no
+// build tag and is always compiled, but it declares only point-name
+// constants, never behavior, so it cannot itself change what a released
+// binary does.
+//
+// The behavior lives behind the conduitchaos build tag:
+//   - chaospoint.go (!conduitchaos): Reach is a no-op. This is what every
+//     released artifact ships, because .goreleaser.yml and
+//     .github/workflows/publish.yml both build with no -tags.
+//   - chaospoint_on.go (conduitchaos): Reach counts each reach of a named
+//     point and, when PGCHAOS_PARK targets that point's Nth reach, announces
+//     PARKED on stdout and blocks the calling goroutine forever. This is
+//     what test/chaos links against to prove a kill lands at an exact,
+//     provably-suspended point instead of a wall-clock guess.
+//
+// The build tag is a security boundary, not a style preference: an
+// untagged, always-live env-var injector would ship a "park this connector
+// forever" switch to every user, where a mistyped or hostile PGCHAOS_PARK
+// becomes a production hang.
+package chaospoint
+
+// Point names identify a specific call site for PGCHAOS_PARK, in the form
+// "<point>:<nth>" (e.g. "snapshot.fetch.row:3" parks at the 3rd reach of
+// SnapshotFetchRow). Names are dotted strings rather than relying on Go
+// identifier reflection, because they are also the human-typed half of that
+// env var — anyone constructing PGCHAOS_PARK works from this file.
+//
+// Adding, renaming, or removing a call site must update this file in the
+// same change: it is the only place the three call sites are enumerated
+// together, and the chaos harness's CI job (go build/vet -tags conduitchaos)
+// exists specifically so a rename here or at a call site fails loudly
+// instead of silently breaking the harness.
+const (
+	// SnapshotFetchRow is reached in source/snapshot/fetch_worker.go's fetch
+	// loop, once per row, immediately after the row is appended to the
+	// pending batch. Parking here proves a kill mid-snapshot: the row is in
+	// memory but not yet sent to the destination.
+	SnapshotFetchRow = "snapshot.fetch.row"
+
+	// PreStartSubscriber is reached as the first statement of
+	// source/logrepl/combined.go's useCDCIterator, before the snapshot
+	// iterator is torn down, before the low-watermark is re-seeded onto the
+	// CDC handler, and before the CDC subscriber starts. Parking here proves
+	// a kill exactly at the snapshot->CDC handoff, before any CDC-side state
+	// (including the watermark carry-forward) has been touched.
+	PreStartSubscriber = "combined.pre_start_subscriber"
+
+	// StandbyStatusUpdate is reached in
+	// source/logrepl/internal/subscription.go's sendStandbyStatusUpdate,
+	// after walFlushed is loaded and the reply-with-WAL-end decision is
+	// computed, but before either status update variant is written to the
+	// replication connection. Parking here proves a kill between "the
+	// engine has decided what the server should learn about flush progress"
+	// and "the server actually learned it" — the window in which a
+	// crash can leave the slot's confirmed_flush_lsn stale relative to what
+	// was actually durably acked.
+	StandbyStatusUpdate = "subscription.standby_status"
+)

--- a/source/logrepl/combined.go
+++ b/source/logrepl/combined.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit-connector-postgres/internal/chaospoint"
 	"github.com/conduitio/conduit-connector-postgres/source/position"
 	"github.com/conduitio/conduit-connector-postgres/source/snapshot"
 	sdk "github.com/conduitio/conduit-connector-sdk"
@@ -262,6 +263,17 @@ func (c *CombinedIterator) initSnapshotIterator(ctx context.Context, pos positio
 // useCDCIterator will activate and start the CDC iterator. The snapshot iterator
 // will be torn down if initialized.
 func (c *CombinedIterator) useCDCIterator(ctx context.Context) error {
+	// Invariant 2 / DBZ-3 B0 kill point (chaospoint.PreStartSubscriber): the
+	// FIRST statement here, before the snapshot iterator is torn down,
+	// before the low watermark is re-seeded, and before StartSubscriber. A
+	// kill landing exactly here proves the snapshot->CDC handoff boundary:
+	// every table's snapshot progress is already persisted (this method is
+	// only reached after NextN observed ErrIteratorDone), but CDC has not
+	// yet consumed or acked anything, so recovery must resume the CDC slot
+	// at RestartLSN, never mid-handoff. No-op outside the conduitchaos
+	// build (see internal/chaospoint).
+	chaospoint.Reach(chaospoint.PreStartSubscriber)
+
 	if c.snapshotIterator != nil {
 		if err := c.snapshotIterator.Teardown(ctx); err != nil {
 			return fmt.Errorf("failed to teardown snapshot iterator during switch: %w", err)

--- a/source/logrepl/internal/subscription.go
+++ b/source/logrepl/internal/subscription.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/conduitio/conduit-connector-postgres/internal/chaospoint"
 	"github.com/conduitio/conduit-connector-postgres/source/cpool"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/jackc/pglogrepl"
@@ -405,6 +406,17 @@ func (s *Subscription) sendStandbyStatusUpdate(ctx context.Context) error {
 	// N.B. Manage replication slot lag, by responding with the last server LSN, when
 	//      all previous slot relevant msgs have been written and flushed
 	replyWithWALEnd := walFlushed == s.walWritten && walFlushed < s.serverWALEnd
+
+	// Invariant 1 / DBZ-3 B0 kill point (chaospoint.StandbyStatusUpdate):
+	// walFlushed is loaded and the reply decision is made, but neither wire
+	// send below has happened yet. A kill landing exactly here proves the
+	// window between "the engine knows what it has durably acked" and "the
+	// server has been told" — if walFlushed < s.walWritten at this point,
+	// Postgres's view of confirmed_flush_lsn must not advance past
+	// walFlushed on the next status update after recovery, or the slot
+	// could prune WAL for records this process never actually acked.
+	// No-op outside the conduitchaos build (see internal/chaospoint).
+	chaospoint.Reach(chaospoint.StandbyStatusUpdate)
 
 	sdk.Logger(ctx).Trace().
 		Stringer("wal_write", s.walWritten).

--- a/source/snapshot/fetch_worker.go
+++ b/source/snapshot/fetch_worker.go
@@ -25,6 +25,7 @@ import (
 	"github.com/conduitio/conduit-commons/opencdc"
 	cschema "github.com/conduitio/conduit-commons/schema"
 	"github.com/conduitio/conduit-connector-postgres/internal"
+	"github.com/conduitio/conduit-connector-postgres/internal/chaospoint"
 	"github.com/conduitio/conduit-connector-postgres/source/position"
 	"github.com/conduitio/conduit-connector-postgres/source/schema"
 	"github.com/conduitio/conduit-connector-postgres/source/types"
@@ -304,6 +305,17 @@ func (f *FetchWorker) fetch(ctx context.Context, tx pgx.Tx) (int, error) {
 		}
 
 		toBeSent = append(toBeSent, data)
+
+		// Invariant 2 / DBZ-3 B0 kill point (chaospoint.SnapshotFetchRow): a
+		// kill landing exactly here proves a mid-batch snapshot crash, where
+		// this row is only in the in-memory toBeSent slice — not yet sent
+		// (f.send, below) and therefore not yet durably acked downstream.
+		// Recovery must resume at f.lastRead (the last row a prior fetch
+		// actually completed sending), never at this row, or the NO GAP /
+		// DUP BOUND properties in the chaos harness would be unprovable.
+		// No-op outside the conduitchaos build (see internal/chaospoint).
+		chaospoint.Reach(chaospoint.SnapshotFetchRow)
+
 		nread++
 	}
 


### PR DESCRIPTION
**Tier 1 — needs your sign-off. Do not merge on green.**

First of five B0 slices: the fault-injection seam the DBZ-3 kill harness needs. No harness yet (that's B0-2) — this is the mechanism plus its proof.

The plan is `conduit-v020-plans/dbz3-b0-kill-harness-plan.md` §3–§4. Origin: adversarial-review finding F2 on the v0.20 plan — three DBZ-3 acceptance criteria (7.5, 7.6, 7.7) assumed a SIGKILL harness that does not exist in this repo, and the work was hidden inside three checkboxes.

## What lands

`internal/chaospoint`, split by build tag. Production call sites are **unconditional and untagged**; only the callee differs:

- `!conduitchaos` → `Reach(name)` is an empty function.
- `conduitchaos` → `Reach` **parks**: prints `PARKED <name> <nth>` and blocks forever at the Nth reach of a named point.

Three call sites, each with a comment saying what a kill there proves:

| File | Point | What it proves |
| --- | --- | --- |
| `source/snapshot/fetch_worker.go:317` | `SnapshotFetchRow` | mid-batch snapshot crash: the row is only in `toBeSent`, not yet sent — recovery must resume at `lastRead` |
| `source/logrepl/combined.go:275` | `PreStartSubscriber` | the snapshot→CDC handoff boundary: snapshot progress persisted, CDC has consumed nothing |
| `source/logrepl/internal/subscription.go:419` | `StandbyStatusUpdate` | the window between "we know what we durably acked" and "the server was told" (invariant 1) |

## Why parking, not timing

The process is provably suspended *at* the point when the signal lands. Timing-based injection is the flake class this project retrofitted `persistDelayMS` to remove — and these points are a single statement wide, orders of magnitude narrower than the ~1s windows the engine chaos tests can hit by wall clock.

## Verified independently, not taken on trust

I re-ran everything in a fresh clone:

- **The injector cannot reach a released binary.** Built the exact `publish.yml` command (`CGO_ENABLED=0 go build -o … ./cmd/connector`, no tags): `strings` finds **0** occurrences of `PGCHAOS_PARK`. The tagged build has 3. That's B0.3 proven directly, not inferred from the YAML.
- Both variants `build` + `vet` clean across the whole repo.
- `TestReachParks` (tagged) and `TestReach_DefaultBuildIsNoOp` (untagged) both pass.

## One finding I fixed before handing this over

The original commit put `build-tags: [conduitchaos]` in `.golangci.yml`. golangci-lint v2 merges config build-tags **additively**, so that makes the *default* `golangci-lint run` — the one `lint.yml` and `make lint` already invoke — analyze the tagged variant and **silently stop analyzing the untagged one**.

That trades one blind spot for a worse one: `chaospoint.go`'s no-op is the code that ships in every release build, and it would have gone unlinted forever with nothing reporting it.

Verified empirically both ways. With the config entry, a deliberate `declared and not used` in the `!conduitchaos` file reported **0 issues**; the same bait in the tagged file was caught. Config reverted, and a `--build-tags conduitchaos` lint step added to the new `chaos-build` job instead — bait in the untagged file is caught again, tagged variant still linted. Two invocations, full coverage.

## Failure-mode analysis

- **Injector reaching production** — foreclosed by the build tag, proven by the `strings` check above. `.goreleaser.yml` and `publish.yml` both build with no `-tags`; if either ever gains one, that property breaks silently, which is why B0.3 is an acceptance criterion rather than a comment.
- **A call site drifting or being deleted in a refactor** — `make test` never compiles the tagged package, so the new `chaos-build` job (every push/PR, no path filter) is what notices. Without it a rename under `source/` would break the harness invisibly.
- **A park that never fires reading as green** — not possible in this slice (nothing kills yet); B0-2 adds `PARK_MISSED` plus a marker deadline.
- **Data path** — `Reach` is an empty function in every shipped build and the call sites are pure statements: no locks, no I/O, no ordering effect. Invariants 1–7 are untouched by this slice. The `-gcflags="-m"` output confirms all three calls inline away.

## Deviation from the plan, and why

The plan says "reads `PGCHAOS_PARK` once at init". A literal `func init()` is untestable in-process — a parked goroutine with nothing else runnable is a genuine deadlock, and Go's detector fires. It reads lazily via `sync.Once` on first `Reach` instead: still exactly once for the process's life (the harness sets the env in `cmd.Env` before the child starts), but reachable from a test with `t.Setenv`.

Roadmap: v0.20 WS7 (DBZ-3), slice B0-1.
